### PR TITLE
Add FixHub landing and static pages

### DIFF
--- a/frontend/about.html
+++ b/frontend/about.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>FixHub</title>
+    <title>Sobre Nosotros - FixHub</title>
     <link rel="stylesheet" href="/style.css" />
   </head>
   <body>
@@ -11,15 +11,15 @@
       <h1>FixHub</h1>
       <nav>
         <ul>
+          <li><a href="/">Inicio</a></li>
           <li><a href="/login.html">Login</a></li>
           <li><a href="/contact.html">Contacto</a></li>
-          <li><a href="/about.html">Sobre Nosotros</a></li>
         </ul>
       </nav>
     </header>
     <main>
-      <h2>Bienvenido a FixHub</h2>
-      <p>Tu plataforma de confianza para gestionar reparaciones.</p>
+      <h2>Sobre Nosotros</h2>
+      <p>FixHub conecta profesionales con clientes para gestionar reparaciones de forma sencilla.</p>
     </main>
     <footer>
       <a href="/terms.html">Términos de servicio</a> |

--- a/frontend/contact.html
+++ b/frontend/contact.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>FixHub</title>
+    <title>Contacto - FixHub</title>
     <link rel="stylesheet" href="/style.css" />
   </head>
   <body>
@@ -11,15 +11,19 @@
       <h1>FixHub</h1>
       <nav>
         <ul>
+          <li><a href="/">Inicio</a></li>
           <li><a href="/login.html">Login</a></li>
-          <li><a href="/contact.html">Contacto</a></li>
           <li><a href="/about.html">Sobre Nosotros</a></li>
         </ul>
       </nav>
     </header>
     <main>
-      <h2>Bienvenido a FixHub</h2>
-      <p>Tu plataforma de confianza para gestionar reparaciones.</p>
+      <h2>Contacto</h2>
+      <form>
+        <label>Correo: <input type="email" name="email" /></label><br />
+        <label>Mensaje:<br /><textarea name="message"></textarea></label><br />
+        <button type="submit">Enviar</button>
+      </form>
     </main>
     <footer>
       <a href="/terms.html">Términos de servicio</a> |

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>FixHub</title>
+    <title>Login - FixHub</title>
     <link rel="stylesheet" href="/style.css" />
   </head>
   <body>
@@ -11,15 +11,19 @@
       <h1>FixHub</h1>
       <nav>
         <ul>
-          <li><a href="/login.html">Login</a></li>
+          <li><a href="/">Inicio</a></li>
           <li><a href="/contact.html">Contacto</a></li>
           <li><a href="/about.html">Sobre Nosotros</a></li>
         </ul>
       </nav>
     </header>
     <main>
-      <h2>Bienvenido a FixHub</h2>
-      <p>Tu plataforma de confianza para gestionar reparaciones.</p>
+      <h2>Login</h2>
+      <form>
+        <label>Usuario: <input type="text" name="username" /></label><br />
+        <label>Contraseña: <input type="password" name="password" /></label><br />
+        <button type="submit">Entrar</button>
+      </form>
     </main>
     <footer>
       <a href="/terms.html">Términos de servicio</a> |

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>FixHub</title>
+    <title>Política de Privacidad - FixHub</title>
     <link rel="stylesheet" href="/style.css" />
   </head>
   <body>
@@ -11,15 +11,15 @@
       <h1>FixHub</h1>
       <nav>
         <ul>
+          <li><a href="/">Inicio</a></li>
           <li><a href="/login.html">Login</a></li>
           <li><a href="/contact.html">Contacto</a></li>
-          <li><a href="/about.html">Sobre Nosotros</a></li>
         </ul>
       </nav>
     </header>
     <main>
-      <h2>Bienvenido a FixHub</h2>
-      <p>Tu plataforma de confianza para gestionar reparaciones.</p>
+      <h2>Política de Privacidad</h2>
+      <p>Esta es la política de privacidad de FixHub.</p>
     </main>
     <footer>
       <a href="/terms.html">Términos de servicio</a> |

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -3,17 +3,37 @@ const fs = require('fs');
 const path = require('path');
 
 const port = process.env.PORT || 3000;
-const indexPath = path.join(__dirname, 'index.html');
+const publicDir = __dirname;
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.js': 'text/javascript',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.ico': 'image/x-icon'
+};
 
 const server = http.createServer((req, res) => {
-  fs.readFile(indexPath, (err, data) => {
+  let reqPath = req.url === '/' ? '/index.html' : req.url;
+  const filePath = path.join(publicDir, reqPath);
+  const ext = path.extname(filePath).toLowerCase();
+  const contentType = mimeTypes[ext] || 'text/plain';
+
+  fs.readFile(filePath, (err, content) => {
     if (err) {
-      res.writeHead(500);
-      res.end('Error loading page');
-      return;
+      if (err.code === 'ENOENT') {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Page not found');
+      } else {
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('Server error');
+      }
+    } else {
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(content);
     }
-    res.writeHead(200, { 'Content-Type': 'text/html' });
-    res.end(data);
   });
 });
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,28 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+header {
+  background: #333;
+  color: #fff;
+  padding: 10px;
+}
+nav ul {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  gap: 10px;
+}
+nav a {
+  color: #fff;
+  text-decoration: none;
+}
+main {
+  padding: 20px;
+}
+footer {
+  background: #f0f0f0;
+  padding: 10px;
+  text-align: center;
+}

--- a/frontend/terms.html
+++ b/frontend/terms.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>FixHub</title>
+    <title>Términos de Servicio - FixHub</title>
     <link rel="stylesheet" href="/style.css" />
   </head>
   <body>
@@ -11,15 +11,15 @@
       <h1>FixHub</h1>
       <nav>
         <ul>
+          <li><a href="/">Inicio</a></li>
           <li><a href="/login.html">Login</a></li>
           <li><a href="/contact.html">Contacto</a></li>
-          <li><a href="/about.html">Sobre Nosotros</a></li>
         </ul>
       </nav>
     </header>
     <main>
-      <h2>Bienvenido a FixHub</h2>
-      <p>Tu plataforma de confianza para gestionar reparaciones.</p>
+      <h2>Términos de Servicio</h2>
+      <p>Estos son los términos de servicio de FixHub.</p>
     </main>
     <footer>
       <a href="/terms.html">Términos de servicio</a> |


### PR DESCRIPTION
## Summary
- Refine FixHub landing page and static pages using shared header, navigation, and footer
- Add basic stylesheet for consistent layout across pages
- Extend Node server to serve CSS and other static assets

## Testing
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_68b19ae42b608325a5df2475a01a6e0e