### PR TITLE
Enhance FixHub landing page UX

### DIFF
--- a/frontend/about.html
+++ b/frontend/about.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sobre Nosotros - FixHub</title>
+    <link rel="stylesheet" href="/style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="logo">FixHub</div>
+      <nav>
+        <ul>
+          <li><a href="/">Inicio</a></li>
+          <li><a href="/login.html">Login</a></li>
+          <li><a href="/contact.html">Contacto</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main>
+      <h2>Sobre Nosotros</h2>
+      <p>FixHub conecta profesionales con clientes para gestionar reparaciones de forma sencilla.</p>
+    </main>
+    <footer>
+      <a href="/terms.html">Términos de servicio</a> |
+      <a href="/privacy.html">Política de privacidad</a>
+    </footer>
+  </body>
+</html>

--- a/frontend/contact.html
+++ b/frontend/contact.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Contacto - FixHub</title>
+    <link rel="stylesheet" href="/style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="logo">FixHub</div>
+      <nav>
+        <ul>
+          <li><a href="/">Inicio</a></li>
+          <li><a href="/login.html">Login</a></li>
+          <li><a href="/about.html">Sobre Nosotros</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main>
+      <h2>Contacto</h2>
+      <form>
+        <label>Correo: <input type="email" name="email" /></label><br />
+        <label>Mensaje:<br /><textarea name="message"></textarea></label><br />
+        <button type="submit">Enviar</button>
+      </form>
+    </main>
+    <footer>
+      <a href="/terms.html">Términos de servicio</a> |
+      <a href="/privacy.html">Política de privacidad</a>
+    </footer>
+  </body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,11 +1,74 @@
 <!DOCTYPE html>
-<html>
+<html lang="es">
   <head>
     <meta charset="UTF-8" />
-    <title>Tradex Frontend</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FixHub</title>
+    <link rel="stylesheet" href="/style.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
   </head>
   <body>
-    <h1>Welcome to Tradex</h1>
-    <p>Frontend powered by Node.</p>
+    <header class="site-header">
+      <div class="logo">FixHub</div>
+      <nav>
+        <ul>
+          <li><a href="/login.html">Login</a></li>
+          <li><a href="/contact.html">Contacto</a></li>
+          <li><a href="/about.html">Sobre Nosotros</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main>
+      <section class="hero">
+        <p class="intro">Bienvenido a FixHub</p>
+        <h2>Encuentra tu profesional de confianza cerca de ti</h2>
+        <div class="cta-buttons">
+          <a href="/login.html" class="btn primary">Soy profesional - Quiero ofrecer mis servicios</a>
+          <a href="#" class="btn secondary">Busco un profesional - Necesito ayuda</a>
+          <a href="/contact.html" class="btn danger">Ayuda - No sé lo que necesito</a>
+        </div>
+      </section>
+      <section class="services">
+        <h3>Servicios Populares</h3>
+        <div class="service-grid">
+          <div class="service-card">
+            <i class="fa-solid fa-bolt"></i>
+            <span>Electricista</span>
+          </div>
+          <div class="service-card">
+            <i class="fa-solid fa-faucet"></i>
+            <span>Fontanero</span>
+          </div>
+          <div class="service-card">
+            <i class="fa-solid fa-hammer"></i>
+            <span>Reformas</span>
+          </div>
+          <div class="service-card">
+            <i class="fa-solid fa-snowflake"></i>
+            <span>Aire Acondicionado</span>
+          </div>
+          <div class="service-card">
+            <i class="fa-solid fa-paint-roller"></i>
+            <span>Pintor</span>
+          </div>
+          <div class="service-card">
+            <i class="fa-solid fa-couch"></i>
+            <span>Montador de Muebles</span>
+          </div>
+          <div class="service-card">
+            <i class="fa-solid fa-key"></i>
+            <span>Cerrajero</span>
+          </div>
+          <div class="service-card">
+            <i class="fa-solid fa-ellipsis-h"></i>
+            <span>Otros</span>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <a href="/terms.html">Términos de servicio</a> |
+      <a href="/privacy.html">Política de privacidad</a>
+    </footer>
   </body>
 </html>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Login - FixHub</title>
+    <link rel="stylesheet" href="/style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="logo">FixHub</div>
+      <nav>
+        <ul>
+          <li><a href="/">Inicio</a></li>
+          <li><a href="/contact.html">Contacto</a></li>
+          <li><a href="/about.html">Sobre Nosotros</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main>
+      <h2>Login</h2>
+      <form>
+        <label>Usuario: <input type="text" name="username" /></label><br />
+        <label>Contraseña: <input type="password" name="password" /></label><br />
+        <button type="submit">Entrar</button>
+      </form>
+    </main>
+    <footer>
+      <a href="/terms.html">Términos de servicio</a> |
+      <a href="/privacy.html">Política de privacidad</a>
+    </footer>
+  </body>
+</html>

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Política de Privacidad - FixHub</title>
+    <link rel="stylesheet" href="/style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="logo">FixHub</div>
+      <nav>
+        <ul>
+          <li><a href="/">Inicio</a></li>
+          <li><a href="/login.html">Login</a></li>
+          <li><a href="/contact.html">Contacto</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main>
+      <h2>Política de Privacidad</h2>
+      <p>Esta es la política de privacidad de FixHub.</p>
+    </main>
+    <footer>
+      <a href="/terms.html">Términos de servicio</a> |
+      <a href="/privacy.html">Política de privacidad</a>
+    </footer>
+  </body>
+</html>

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -3,17 +3,37 @@ const fs = require('fs');
 const path = require('path');
 
 const port = process.env.PORT || 3000;
-const indexPath = path.join(__dirname, 'index.html');
+const publicDir = __dirname;
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.js': 'text/javascript',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.ico': 'image/x-icon'
+};
 
 const server = http.createServer((req, res) => {
-  fs.readFile(indexPath, (err, data) => {
+  let reqPath = req.url === '/' ? '/index.html' : req.url;
+  const filePath = path.join(publicDir, reqPath);
+  const ext = path.extname(filePath).toLowerCase();
+  const contentType = mimeTypes[ext] || 'text/plain';
+
+  fs.readFile(filePath, (err, content) => {
     if (err) {
-      res.writeHead(500);
-      res.end('Error loading page');
-      return;
+      if (err.code === 'ENOENT') {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Page not found');
+      } else {
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('Server error');
+      }
+    } else {
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(content);
     }
-    res.writeHead(200, { 'Content-Type': 'text/html' });
-    res.end(data);
   });
 });
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,117 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background: #f9fafb;
+  color: #333;
+}
+
+.site-header {
+  background: #0d1b2a;
+  color: #fff;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 15px 20px;
+}
+
+.logo {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 15px;
+  margin: 0;
+  padding: 0;
+}
+
+nav a {
+  color: #fff;
+  text-decoration: none;
+}
+
+.hero {
+  background: linear-gradient(135deg, #1b2a4e, #0d1b2a);
+  color: #fff;
+  text-align: center;
+  padding: 80px 20px;
+}
+
+.hero .intro {
+  font-size: 1.2rem;
+  margin-bottom: 10px;
+}
+
+.hero h2 {
+  font-size: 2rem;
+  margin: 0 auto 20px;
+  max-width: 700px;
+}
+
+.cta-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 15px;
+}
+
+.btn {
+  display: inline-block;
+  padding: 10px 20px;
+  border-radius: 5px;
+  text-decoration: none;
+  color: #fff;
+  font-weight: bold;
+}
+
+.btn.primary {
+  background: #2563eb;
+}
+
+.btn.secondary {
+  background: #10b981;
+}
+
+.btn.danger {
+  background: #ef4444;
+}
+
+.services {
+  padding: 40px 20px;
+}
+
+.services h3 {
+  text-align: center;
+  margin-bottom: 30px;
+}
+
+.service-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 20px;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.service-card {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 20px;
+  text-align: center;
+}
+
+.service-card i {
+  font-size: 2rem;
+  color: #2563eb;
+  margin-bottom: 10px;
+}
+
+footer {
+  background: #f0f0f0;
+  padding: 10px;
+  text-align: center;
+}

--- a/frontend/terms.html
+++ b/frontend/terms.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Términos de Servicio - FixHub</title>
+    <link rel="stylesheet" href="/style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="logo">FixHub</div>
+      <nav>
+        <ul>
+          <li><a href="/">Inicio</a></li>
+          <li><a href="/login.html">Login</a></li>
+          <li><a href="/contact.html">Contacto</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main>
+      <h2>Términos de Servicio</h2>
+      <p>Estos son los términos de servicio de FixHub.</p>
+    </main>
+    <footer>
+      <a href="/terms.html">Términos de servicio</a> |
+      <a href="/privacy.html">Política de privacidad</a>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add hero section with Spanish welcome, call-to-action buttons, and popular service grid
- Apply shared header and responsive styling across static pages

## Testing
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_68b19ae42b608325a5df2475a01a6e0e