### PR TITLE
feat: add FastAPI backend with health endpoint

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,6 @@
 FROM python:3.11-slim
 WORKDIR /app
-COPY app.py /app/app.py
-CMD ["python", "app.py"]
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py /app/main.py
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python3
-
-def main():
-    # TODO: Implement backend logic
-    pass
-
-if __name__ == "__main__":
-    main()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pydantic


### PR DESCRIPTION
## Summary
- add FastAPI app with `/health` route
- define backend dependencies in requirements.txt
- update Dockerfile to install dependencies and launch app via uvicorn

## Testing
- `python -m py_compile backend/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6e594ca78832597b40da6d93c28e7