### PR TITLE
Add SQLAlchemy models and Alembic migrations

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,38 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite:///./sql_app.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S
+

--- a/backend/alembic/README
+++ b/backend/alembic/README
@@ -1,0 +1,2 @@
+Generic single-database configuration.
+

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,50 @@
+from logging.config import fileConfig
+import os
+import sys
+
+from sqlalchemy import engine_from_config
+from alembic import context
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from core.database import SQLALCHEMY_DATABASE_URL, Base
+
+config = context.config
+config.set_main_option("sqlalchemy.url", SQLALCHEMY_DATABASE_URL)
+
+fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline():
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()
+

--- a/backend/alembic/script.py.mako
+++ b/backend/alembic/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}
+

--- a/backend/alembic/versions/0001_initial.py
+++ b/backend/alembic/versions/0001_initial.py
@@ -1,0 +1,51 @@
+"""init
+
+Revision ID: 0001
+Revises: 
+Create Date: 2023-01-01 00:00:00
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'users',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('email', sa.String(), nullable=False),
+        sa.Column('hashed_password', sa.String(), nullable=False),
+        sa.Column('is_active', sa.Boolean(), nullable=True),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index('ix_users_id', 'users', ['id'], unique=False)
+    op.create_index('ix_users_email', 'users', ['email'], unique=True)
+
+    op.create_table(
+        'tasks',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('title', sa.String(), nullable=False),
+        sa.Column('description', sa.String(), nullable=True),
+        sa.Column('owner_id', sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(['owner_id'], ['users.id']),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index('ix_tasks_id', 'tasks', ['id'], unique=False)
+    op.create_index('ix_tasks_title', 'tasks', ['title'], unique=False)
+
+
+def downgrade():
+    op.drop_index('ix_tasks_title', table_name='tasks')
+    op.drop_index('ix_tasks_id', table_name='tasks')
+    op.drop_table('tasks')
+    op.drop_index('ix_users_email', table_name='users')
+    op.drop_index('ix_users_id', table_name='users')
+    op.drop_table('users')
+

--- a/backend/api/models/__init__.py
+++ b/backend/api/models/__init__.py
@@ -1,0 +1,4 @@
+from .user import User
+from .task import Task
+
+__all__ = ["User", "Task"]

--- a/backend/api/models/task.py
+++ b/backend/api/models/task.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy.orm import relationship
+
+from core.database import Base
+
+
+class Task(Base):
+    __tablename__ = "tasks"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, index=True, nullable=False)
+    description = Column(String, nullable=True)
+    owner_id = Column(Integer, ForeignKey("users.id"))
+
+    owner = relationship("User", back_populates="tasks")
+

--- a/backend/api/models/user.py
+++ b/backend/api/models/user.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, Integer, String, Boolean
+from sqlalchemy.orm import relationship
+
+from core.database import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, unique=True, index=True, nullable=False)
+    hashed_password = Column(String, nullable=False)
+    is_active = Column(Boolean, default=True)
+
+    tasks = relationship("Task", back_populates="owner")
+

--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -1,0 +1,13 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./sql_app.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,7 @@
-fastapi
-uvicorn
-pydantic
+fastapi==0.110.0
+uvicorn==0.27.1
+pydantic==2.5.3
 
-pydantic-settings
+pydantic-settings==2.0.3
+sqlalchemy==2.0.23
+alembic==1.12.1


### PR DESCRIPTION
## Summary
- add SQLAlchemy and Alembic dependencies
- implement database setup and models
- configure Alembic with initial migration
- pin backend dependencies for reproducible installs

## Testing
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.110.0)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6e8cc8798832598ef6904095d4752