### PR TITLE
Link hero FixHub text to homepage and replace header logo

### DIFF
--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -24,7 +24,7 @@
         </div>
         <div> <br></div>
         <p class="lead">
-          FixHub:  <strong>tu oficina en el bolsillo.</strong> Para profesionales. Electricistas, fontaneros, pintores, reformistas, técnicos de mantenimiento... 
+          <a href="./index.html" class="brand-link">FixHub</a>:  <strong>tu oficina en el bolsillo.</strong> Para profesionales. Electricistas, fontaneros, pintores, reformistas, técnicos de mantenimiento... 
           Desde la solicitud del cliente hasta la factura electrónica. Todo en un solo lugar, siempre contigo.
         </p>
       </div>

--- a/frontend/public/css/style.css
+++ b/frontend/public/css/style.css
@@ -77,9 +77,14 @@ body{
   display:flex; align-items:center; gap:.6rem;
 }
 .logo::before{
-  content:""; width:22px; height:22px; border-radius:6px;
-  background: conic-gradient(from 220deg at 60% 40%, var(--amber), var(--sky) 60%, var(--orange));
-  box-shadow: inset 0 0 0 2px rgba(255,255,255,.15);
+  content:""; width:22px; height:22px; border-radius:0;
+  background: url("/images/Logo_fh.png") no-repeat center/cover;
+  box-shadow:none;
+}
+
+.brand-link{
+  color:inherit;
+  text-decoration:none;
 }
 nav ul{
   list-style:none; display:flex; gap:20px; margin:0; padding:0;


### PR DESCRIPTION
## Summary
- Link the hero section's "FixHub" text to the homepage without default hyperlink styling
- Replace header's gradient square logo with provided image

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b6eb780db48325949e87d6858a0843