### PR TITLE
Add health endpoint test and DB override fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from backend.core.database import Base
+import backend.core.database as database
+
+# Create an in-memory SQLite engine
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+@pytest.fixture(scope="session", autouse=True)
+def override_session_local():
+    database.SessionLocal = TestingSessionLocal
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+@pytest.fixture()
+def db_session():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+def test_health():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add pytest for `/health` endpoint
- provide test fixtures using in-memory SQLite and override `SessionLocal`

## Testing
- `pytest -q` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68b6ec6c9134832586c163906bed0b2f