### PR TITLE
Add authentication routes with JWT support

### DIFF
--- a/backend/api/routers/__init__.py
+++ b/backend/api/routers/__init__.py
@@ -1,3 +1,4 @@
 from .health import router as health_router
+from .auth import router as auth_router
 
-routers = [health_router]
+routers = [health_router, auth_router]

--- a/backend/api/routers/auth.py
+++ b/backend/api/routers/auth.py
@@ -1,0 +1,94 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, EmailStr
+from sqlalchemy.orm import Session
+from passlib.context import CryptContext
+from jose import JWTError, jwt
+
+from backend.core.database import SessionLocal
+from backend.api.models.user import User
+
+SECRET_KEY = "secret"
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+router = APIRouter()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+class UserBase(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class ForgotPasswordRequest(BaseModel):
+    email: EmailStr
+
+
+class ResetPasswordRequest(BaseModel):
+    token: str
+    new_password: str
+
+
+@router.post("/register")
+def register(user: UserBase, db: Session = Depends(get_db)):
+    existing = db.query(User).filter(User.email == user.email).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="Email already registered")
+    db_user = User(email=user.email, hashed_password=pwd_context.hash(user.password))
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    token = create_access_token({"sub": str(db_user.id)})
+    return {"access_token": token}
+
+
+@router.post("/login")
+def login(user: UserBase, db: Session = Depends(get_db)):
+    db_user = db.query(User).filter(User.email == user.email).first()
+    if not db_user or not pwd_context.verify(user.password, db_user.hashed_password):
+        raise HTTPException(status_code=400, detail="Incorrect email or password")
+    token = create_access_token({"sub": str(db_user.id)})
+    return {"access_token": token}
+
+
+@router.post("/forgotpassword")
+def forgot_password(req: ForgotPasswordRequest, db: Session = Depends(get_db)):
+    db_user = db.query(User).filter(User.email == req.email).first()
+    if not db_user:
+        raise HTTPException(status_code=404, detail="User not found")
+    token = create_access_token({"sub": str(db_user.id)}, expires_delta=timedelta(hours=1))
+    return {"reset_token": token}
+
+
+@router.post("/reset")
+def reset_password(req: ResetPasswordRequest, db: Session = Depends(get_db)):
+    try:
+        payload = jwt.decode(req.token, SECRET_KEY, algorithms=[ALGORITHM])
+        user_id = payload.get("sub")
+    except JWTError:
+        raise HTTPException(status_code=400, detail="Invalid token")
+    db_user = db.query(User).filter(User.id == int(user_id)).first()
+    if not db_user:
+        raise HTTPException(status_code=404, detail="User not found")
+    db_user.hashed_password = pwd_context.hash(req.new_password)
+    db.commit()
+    return {"status": "password reset"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,8 +1,7 @@
-fastapi==0.110.0
-uvicorn==0.27.1
-pydantic==2.5.3
-
-pydantic-settings==2.0.3
+fastapi==0.116.1
+uvicorn==0.35.0
+pydantic==2.11.7
+pydantic-settings==2.10.1
 sqlalchemy==2.0.23
 alembic==1.12.1
 passlib[bcrypt]==1.7.4

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,5 @@ pydantic==2.5.3
 pydantic-settings==2.0.3
 sqlalchemy==2.0.23
 alembic==1.12.1
+passlib[bcrypt]==1.7.4
+python-jose==3.3.0

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,48 @@
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+def register_user(email: str = "user@example.com", password: str = "secret"):
+    return client.post("/register", json={"email": email, "password": password})
+
+
+def login_user(email: str = "user@example.com", password: str = "secret"):
+    return client.post("/login", json={"email": email, "password": password})
+
+
+def forgot_password(email: str = "user@example.com"):
+    return client.post("/forgotpassword", json={"email": email})
+
+
+def reset_password(token: str, new_password: str):
+    return client.post("/reset", json={"token": token, "new_password": new_password})
+
+
+def test_register_and_login(db_session):
+    response = register_user()
+    assert response.status_code == 200
+    assert "access_token" in response.json()
+
+    response = login_user()
+    assert response.status_code == 200
+    assert "access_token" in response.json()
+
+
+def test_forgot_and_reset(db_session):
+    register_user()
+    response = forgot_password()
+    assert response.status_code == 200
+    token = response.json()["reset_token"]
+
+    response = reset_password(token, "newsecret")
+    assert response.status_code == 200
+
+    # login with new password
+    response = login_user(password="newsecret")
+    assert response.status_code == 200
+
+    # old password should fail
+    response = login_user(password="secret")
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary
- add authentication router with register/login/password reset endpoints
- hash passwords and issue JWTs
- test basic auth flows

## Testing
- `pip install -r backend/requirements.txt` (fails: Could not find a version that satisfies the requirement fastapi==0.110.0)
- `pytest -q` (fails: ModuleNotFoundError: No module named 'sqlalchemy')

------
https://chatgpt.com/codex/tasks/task_e_68b6ef91e274832591fe693396fc75ac