### PR TITLE
Add task router with user association

### DIFF
--- a/backend/api/routers/__init__.py
+++ b/backend/api/routers/__init__.py
@@ -1,3 +1,4 @@
 from .health import router as health_router
+from .tasks import router as tasks_router
 
-routers = [health_router]
+routers = [health_router, tasks_router]

--- a/backend/api/routers/tasks.py
+++ b/backend/api/routers/tasks.py
@@ -1,0 +1,87 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from sqlalchemy.orm import Session
+
+from api.models.task import Task
+from api.models.user import User
+from api.schemas import TaskCreate, TaskUpdate, TaskRead
+from core.database import SessionLocal
+
+router = APIRouter(prefix="/v1/tasks", tags=["tasks"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def get_current_user(
+    db: Session = Depends(get_db), user_id: int = Header(..., alias="X-User-Id")
+):
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid user")
+    return user
+
+
+@router.get("", response_model=List[TaskRead])
+def list_tasks(
+    db: Session = Depends(get_db), current_user: User = Depends(get_current_user)
+):
+    return db.query(Task).filter(Task.owner_id == current_user.id).all()
+
+
+@router.post("", response_model=TaskRead)
+def create_task(
+    task_in: TaskCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    task = Task(**task_in.dict(), owner_id=current_user.id)
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return task
+
+
+@router.patch("/{task_id}", response_model=TaskRead)
+def update_task(
+    task_id: int,
+    task_in: TaskUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    task = (
+        db.query(Task)
+        .filter(Task.id == task_id, Task.owner_id == current_user.id)
+        .first()
+    )
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    for key, value in task_in.dict(exclude_unset=True).items():
+        setattr(task, key, value)
+    db.commit()
+    db.refresh(task)
+    return task
+
+
+@router.delete("/{task_id}")
+def delete_task(
+    task_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    task = (
+        db.query(Task)
+        .filter(Task.id == task_id, Task.owner_id == current_user.id)
+        .first()
+    )
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    db.delete(task)
+    db.commit()
+    return {"ok": True}

--- a/backend/api/schemas/__init__.py
+++ b/backend/api/schemas/__init__.py
@@ -1,0 +1,1 @@
+from .task import TaskCreate, TaskUpdate, TaskRead

--- a/backend/api/schemas/task.py
+++ b/backend/api/schemas/task.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class TaskBase(BaseModel):
+    title: str
+    description: Optional[str] = None
+
+
+class TaskCreate(TaskBase):
+    pass
+
+
+class TaskUpdate(BaseModel):
+    title: Optional[str] = None
+    description: Optional[str] = None
+
+
+class TaskRead(TaskBase):
+    id: int
+    owner_id: int
+
+    class Config:
+        orm_mode = True

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,58 @@
+from fastapi.testclient import TestClient
+from main import app
+from backend.api.models.user import User
+
+client = TestClient(app)
+
+def create_user(db):
+    user = User(email="user@example.com", hashed_password="pwd")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def test_create_and_list_tasks(db_session):
+    user = create_user(db_session)
+    response = client.post(
+        "/v1/tasks",
+        json={"title": "Test", "description": "desc"},
+        headers={"X-User-Id": str(user.id)},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == "Test"
+    assert data["owner_id"] == user.id
+
+    resp = client.get("/v1/tasks", headers={"X-User-Id": str(user.id)})
+    assert resp.status_code == 200
+    tasks = resp.json()
+    assert len(tasks) == 1
+    assert tasks[0]["id"] == data["id"]
+
+
+def test_update_and_delete_task(db_session):
+    user = create_user(db_session)
+    create_resp = client.post(
+        "/v1/tasks",
+        json={"title": "Task", "description": None},
+        headers={"X-User-Id": str(user.id)},
+    )
+    task_id = create_resp.json()["id"]
+
+    update_resp = client.patch(
+        f"/v1/tasks/{task_id}",
+        json={"title": "Updated"},
+        headers={"X-User-Id": str(user.id)},
+    )
+    assert update_resp.status_code == 200
+    assert update_resp.json()["title"] == "Updated"
+
+    delete_resp = client.delete(
+        f"/v1/tasks/{task_id}", headers={"X-User-Id": str(user.id)}
+    )
+    assert delete_resp.status_code == 200
+
+    list_resp = client.get("/v1/tasks", headers={"X-User-Id": str(user.id)})
+    assert list_resp.status_code == 200
+    assert list_resp.json() == []


### PR DESCRIPTION
## Summary
- create Task Pydantic schemas
- implement user-scoped task API router for CRUD endpoints
- add tests for task routes

## Testing
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.110.0; Cannot connect to proxy)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68b6f5ab431883258d03c491595ca299