### PR TITLE
Add legal compliance info to terms, privacy, and admin pages

### DIFF
--- a/frontend/pages/admin.html
+++ b/frontend/pages/admin.html
@@ -52,6 +52,35 @@
     <button class="btn secondary">Descargar mis datos</button>
     <button class="btn secondary">Solicitar borrado</button>
   </section>
+
+  <section class="card">
+    <h3>Requisitos legales recomendados</h3>
+    <h4>Gestión fiscal y facturación</h4>
+    <ul>
+      <li>Visualizar y descargar facturas propias de la suscripción SaaS.</li>
+      <li>Sistema de numeración único para facturas y presupuestos.</li>
+      <li>Exportar libros en formato CSV o compatible con AEAT.</li>
+    </ul>
+    <h4>RGPD y privacidad</h4>
+    <ul>
+      <li>Acceso al registro de consentimiento y panel de gestión de cookies.</li>
+      <li>Exportar datos personales en formatos JSON o XML.</li>
+      <li>Trazabilidad de acciones mediante logs legales.</li>
+    </ul>
+    <h4>Términos y condiciones</h4>
+    <ul>
+      <li>Enlace directo a <a href="./terms.html">Términos de uso</a>, <a href="./privacy.html">Política de privacidad</a>, <a href="./cookies.html">Política de cookies</a> y <a href="./contract.html">Condiciones de contratación</a>.</li>
+    </ul>
+    <h4>Gestión de usuarios y permisos</h4>
+    <ul>
+      <li>Accesos diferenciados por roles.</li>
+      <li>Historial de acciones por usuario.</li>
+    </ul>
+    <h4>Certificados o compliance</h4>
+    <ul>
+      <li>Soporte para certificados como ISO 27001 o sello ENS si se gestionan datos sensibles.</li>
+    </ul>
+  </section>
 </main>
 
 <!--#include "partials/footer.html" -->

--- a/frontend/pages/privacy.html
+++ b/frontend/pages/privacy.html
@@ -111,25 +111,55 @@
   <h2>11. Datos para facturación y veracidad</h2>
   <div class="callout">
     <p>
-      Cuando generes facturas en FixHub, te comprometes a proporcionar datos <strong>completos y veraces</strong> (datos fiscales, NIF/NIE, direcciones, conceptos e importes). 
+      Cuando generes facturas en FixHub, te comprometes a proporcionar datos <strong>completos y veraces</strong> (datos fiscales, NIF/NIE, direcciones, conceptos e importes).
       FixHub no se hace responsable de errores por información incorrecta o incompleta introducida por el usuario.
     </p>
   </div>
 
-  <h2>12. Menores</h2>
+  <h2>12. Elementos legales según funcionalidades</h2>
+  <h3>1. Gestión y generación automática de presupuestos</h3>
+  <ul>
+    <li>Aviso legal como herramienta técnica sin responsabilidad sobre la validez jurídica del presupuesto.</li>
+    <li>El profesional debe revisar y validar cada presupuesto generado.</li>
+    <li>Posibilidad de incluir firma digital o aceptación del cliente.</li>
+    <li>Histórico de versiones para trazabilidad.</li>
+  </ul>
+  <p><strong>Normativa relacionada:</strong> Ley 34/2002 LSSI-CE; Código Civil art. 1254 y ss.</p>
+
+  <h3>2. Incorporación de generación de facturas</h3>
+  <ul>
+    <li>Númeración correlativa, fecha de emisión y datos fiscales del emisor y receptor.</li>
+    <li>Desglose de IVA y retenciones cuando proceda.</li>
+    <li>Archivo durante un mínimo de cuatro años y exportación en PDF o Excel.</li>
+    <li>Conservación de facturas electrónicas según art. 29 de la Ley General Tributaria y RD 1619/2012.</li>
+    <li>Validación de NIF en la emisión de facturas.</li>
+  </ul>
+  <p><strong>Normativa relacionada:</strong> RD 1619/2012; Ley 58/2003; Ley 37/1992 del IVA.</p>
+
+  <h3>3. Cobro por servicios – Plataforma SaaS</h3>
+  <ul>
+    <li>Emisión de factura al profesional que contrata el servicio.</li>
+    <li>Política de precios y cancelación clara en los términos.</li>
+    <li>Aceptación obligatoria de condiciones legales y de privacidad.</li>
+    <li>Política de devolución y desistimiento si se ofrece.</li>
+    <li>Cumplimiento de la LSSI-CE y de la normativa de protección de datos (GDPR y LOPDGDD).</li>
+  </ul>
+  <p><strong>Normativa relacionada:</strong> LOPDGDD; Reglamento (UE) 2016/679; Ley 34/2002; Ley General para la Defensa de los Consumidores y Usuarios.</p>
+
+  <h2>13. Menores</h2>
   <p>
     FixHub no está dirigida a menores de 18 años y no recaba intencionadamente sus datos.
   </p>
 
-  <h2>13. Cambios en esta política</h2>
+  <h2>14. Cambios en esta política</h2>
   <p>
     Podremos actualizar esta política para reflejar cambios legales o del servicio. Publicaremos la versión vigente en esta página e indicaremos la fecha de entrada en vigor.
     Si los cambios son sustanciales, te lo notificaremos por los medios de contacto disponibles.
   </p>
 
-  <h2>14. Contacto</h2>
+  <h2>15. Contacto</h2>
   <p>
-    Si tienes preguntas sobre privacidad o quieres ejercer tus derechos, contáctanos en 
+    Si tienes preguntas sobre privacidad o quieres ejercer tus derechos, contáctanos en
     <a class="link" href="mailto:opotek+fixhub@protonmail.com">opotek+fixhub@protonmail.com</a>.
   </p>
 

--- a/frontend/pages/terms.html
+++ b/frontend/pages/terms.html
@@ -86,14 +86,45 @@
 
   <h2>7. Uso aceptable</h2>
   <p>
-    No está permitido utilizar FixHub para actividades ilícitas, fraudulentas o que vulneren derechos 
-    de terceros. El incumplimiento de estas condiciones puede dar lugar a la suspensión o cancelación 
+    No está permitido utilizar FixHub para actividades ilícitas, fraudulentas o que vulneren derechos
+    de terceros. El incumplimiento de estas condiciones puede dar lugar a la suspensión o cancelación
     de la cuenta.
   </p>
 
-  <h2>8. Contacto</h2>
+  <h2>8. Elementos legales según funcionalidades</h2>
+  <h3>1. Gestión y generación automática de presupuestos</h3>
+  <ul>
+    <li>Aviso legal: actuamos como herramienta técnica sin asumir la validez jurídica del presupuesto emitido.</li>
+    <li>Cláusula de uso correcto: el profesional debe revisar y validar los presupuestos generados.</li>
+    <li>Firma digital opcional para aceptar presupuestos mediante servicios externos.</li>
+    <li>Histórico de versiones para asegurar trazabilidad legal.</li>
+  </ul>
+  <p><strong>Normativa relacionada:</strong> Ley 34/2002 de Servicios de la Sociedad de la Información y Comercio Electrónico; Código Civil, art. 1254 y ss.</p>
+
+  <h3>2. Incorporación de generación de facturas</h3>
+  <ul>
+    <li>Número correlativo, fecha de emisión y datos fiscales completos.</li>
+    <li>Desglose de IVA y retenciones cuando proceda.</li>
+    <li>Archivo legal durante al menos cuatro años y exportación en PDF o Excel.</li>
+    <li>Conservación de facturas electrónicas conforme a la Ley General Tributaria y RD 1619/2012.</li>
+    <li>Validación del NIF de clientes y emisores.</li>
+  </ul>
+  <p><strong>Normativa relacionada:</strong> RD 1619/2012; Ley 58/2003 General Tributaria; Ley 37/1992 del IVA.</p>
+
+  <h3>3. Cobro por servicios – Plataforma SaaS</h3>
+  <ul>
+    <li>Emisión de factura al profesional que contrata el servicio.</li>
+    <li>Política de precios y cancelación clara.</li>
+    <li>Sistema de aceptación de condiciones legales y privacidad mediante checkbox obligatorio.</li>
+    <li>Política de devolución y desistimiento si se ofrece.</li>
+    <li>Adaptación a la LSSI-CE: identificación del prestador, contacto, cookies y condiciones de uso.</li>
+    <li>Política de protección de datos acorde a GDPR y LOPDGDD, con posibilidad de ejercer derechos ARSULIPO y registro de actividades.</li>
+  </ul>
+  <p><strong>Normativa relacionada:</strong> LOPDGDD; Reglamento (UE) 2016/679; Ley 34/2002 LSSI-CE; Ley General para la Defensa de los Consumidores y Usuarios.</p>
+
+  <h2>9. Contacto</h2>
   <p>
-    Para cualquier duda sobre estas condiciones, puedes escribirnos a 
+    Para cualquier duda sobre estas condiciones, puedes escribirnos a
     <a href="mailto:opotek+fixhub@protonmail.com" class="link">opotek+fixhub@protonmail.com</a>.
   </p>
 </main>


### PR DESCRIPTION
## Summary
- document legal obligations for budgets, invoicing, and SaaS billing in terms and privacy pages
- expand admin page with recommended legal and compliance sections

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.110.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f877a1808325997667899d5535bf