### PR TITLE
Add custom exceptions and global handlers

### DIFF
--- a/backend/core/exceptions.py
+++ b/backend/core/exceptions.py
@@ -1,0 +1,33 @@
+class AppException(Exception):
+    """Base application exception."""
+
+    status_code: int = 500
+    message: str = "Internal Server Error"
+
+    def __init__(self, message: str | None = None):
+        if message is not None:
+            self.message = message
+
+    def __str__(self) -> str:
+        return self.message
+
+
+class UnauthorizedException(AppException):
+    """Exception raised for unauthorized access."""
+
+    status_code = 401
+    message = "Unauthorized"
+
+
+class ForbiddenException(AppException):
+    """Exception raised for forbidden access."""
+
+    status_code = 403
+    message = "Forbidden"
+
+
+class UnprocessableEntityException(AppException):
+    """Exception raised for unprocessable entities."""
+
+    status_code = 422
+    message = "Unprocessable Entity"

--- a/main.py
+++ b/main.py
@@ -1,7 +1,34 @@
 from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
 
 from backend.api.routers import routers
+from backend.core.exceptions import AppException
 
 app = FastAPI()
 for router in routers:
     app.include_router(router)
+
+
+@app.exception_handler(AppException)
+async def app_exception_handler(request, exc: AppException):
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"status": exc.status_code, "message": exc.message},
+    )
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request, exc: RequestValidationError):
+    return JSONResponse(
+        status_code=422,
+        content={"status": 422, "message": "Validation Error"},
+    )
+
+
+@app.exception_handler(Exception)
+async def generic_exception_handler(request, exc: Exception):
+    return JSONResponse(
+        status_code=500,
+        content={"status": 500, "message": "Internal Server Error"},
+    )

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,64 @@
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+from main import app
+from backend.core.exceptions import (
+    ForbiddenException,
+    UnauthorizedException,
+    UnprocessableEntityException,
+)
+
+client = TestClient(app)
+
+
+def test_unauthorized_handler():
+    @app.get("/unauthorized-test")
+    def unauthorized_test():
+        raise UnauthorizedException("no auth")
+
+    response = client.get("/unauthorized-test")
+    assert response.status_code == 401
+    assert response.json() == {"status": 401, "message": "no auth"}
+
+
+def test_forbidden_handler():
+    @app.get("/forbidden-test")
+    def forbidden_test():
+        raise ForbiddenException("no access")
+
+    response = client.get("/forbidden-test")
+    assert response.status_code == 403
+    assert response.json() == {"status": 403, "message": "no access"}
+
+
+def test_unprocessable_entity_handler():
+    @app.get("/unprocessable-test")
+    def unprocessable_test():
+        raise UnprocessableEntityException("bad entity")
+
+    response = client.get("/unprocessable-test")
+    assert response.status_code == 422
+    assert response.json() == {"status": 422, "message": "bad entity"}
+
+
+def test_validation_error_handler():
+    class Item(BaseModel):
+        name: str
+
+    @app.post("/validation-test")
+    def validation_test(item: Item):
+        return item
+
+    response = client.post("/validation-test", json={"wrong": "value"})
+    assert response.status_code == 422
+    assert response.json() == {"status": 422, "message": "Validation Error"}
+
+
+def test_generic_exception_handler():
+    @app.get("/generic-error-test")
+    def generic_error_test():
+        raise Exception("boom")
+
+    response = client.get("/generic-error-test")
+    assert response.status_code == 500
+    assert response.json() == {"status": 500, "message": "Internal Server Error"}


### PR DESCRIPTION
## Summary
- add application-specific exceptions
- standardize JSON responses with global FastAPI handlers
- cover new handlers with tests

## Testing
- `pytest` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68b6f89a55c48325b857cb7de215ed63