### PR TITLE
Add Docker Compose setup for API and database

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+POSTGRES_USER=tradex
+POSTGRES_PASSWORD=tradex
+POSTGRES_DB=tradex
+DATABASE_URL=postgresql://tradex:tradex@db:5432/tradex

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,13 @@
 FROM python:3.11-slim
+
 WORKDIR /app
-COPY requirements.txt /app/requirements.txt
+
+# Install Python dependencies
+COPY backend/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application source
+COPY backend /app/backend
 COPY main.py /app/main.py
+
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -3,6 +3,7 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     app_name: str = "Tradex"
+    database_url: str = "sqlite:///./sql_app.db"
 
     class Config:
         env_file = ".env"

--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -1,13 +1,14 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./sql_app.db"
+from .config import settings
 
+SQLALCHEMY_DATABASE_URL = settings.database_url
+connect_args = {"check_same_thread": False} if SQLALCHEMY_DATABASE_URL.startswith("sqlite") else {}
 engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+    SQLALCHEMY_DATABASE_URL, connect_args=connect_args
 )
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.9"
+services:
+  api:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    env_file: .env
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+  db:
+    image: postgres:15-alpine
+    env_file: .env
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+volumes:
+  postgres_data:

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,17 @@
-hello
+# Tradex
+
+## Running with Docker
+
+The project uses `docker-compose` to start the API and database services. Ensure the `.env` file is present, then start everything with:
+
+```bash
+docker-compose up --build
+```
+
+The API will be available at http://localhost:8000 and a PostgreSQL database will be created with the credentials defined in `.env`.
+
+To stop and remove containers:
+
+```bash
+docker-compose down
+```


### PR DESCRIPTION
## Summary
- install backend dependencies and copy source in Dockerfile
- load database URL from `.env`
- add `.env` and `docker-compose.yml` to run API with Postgres
- document Docker start commands in `readme.md`

## Testing
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.110.0)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68b6fc0e9864832582abf2db5ec141e4