### PR TITLE
Prefix API routers with versioned path and adjust tests

### DIFF
--- a/backend/api/routers/__init__.py
+++ b/backend/api/routers/__init__.py
@@ -1,6 +1,6 @@
+from .auth import router as auth_router
 from .health import router as health_router
-
 from .tasks import router as tasks_router
 
-routers = [health_router, tasks_router]
+routers = [health_router, tasks_router, auth_router]
 

--- a/backend/api/routers/auth.py
+++ b/backend/api/routers/auth.py
@@ -16,7 +16,7 @@ ACCESS_TOKEN_EXPIRE_MINUTES = 30
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
-router = APIRouter()
+router = APIRouter(prefix="/api-v1/auth")
 
 
 def get_db():

--- a/backend/api/routers/health.py
+++ b/backend/api/routers/health.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter
 
-router = APIRouter()
+router = APIRouter(prefix="/api-v1/health")
 
-@router.get("/health")
+
+@router.get("")
 def health():
     return {"status": "ok"}

--- a/backend/api/routers/tasks.py
+++ b/backend/api/routers/tasks.py
@@ -8,7 +8,7 @@ from api.models.user import User
 from api.schemas import TaskCreate, TaskUpdate, TaskRead
 from core.database import SessionLocal
 
-router = APIRouter(prefix="/v1/tasks", tags=["tasks"])
+router = APIRouter(prefix="/api-v1/tasks", tags=["tasks"])
 
 
 def get_db():

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -7,6 +7,7 @@ class Settings(BaseSettings):
 
     class Config:
         env_file = ".env"
+        extra = "ignore"
 
 
 settings = Settings()

--- a/main.py
+++ b/main.py
@@ -2,11 +2,11 @@ from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
-from backend.api.routers import routers
+from backend.api.routers import routers as api_routers
 from backend.core.exceptions import AppException
 
 app = FastAPI()
-for router in routers:
+for router in api_routers:
     app.include_router(router)
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,19 +5,25 @@ client = TestClient(app)
 
 
 def register_user(email: str = "user@example.com", password: str = "secret"):
-    return client.post("/register", json={"email": email, "password": password})
+    return client.post(
+        "/api-v1/auth/register", json={"email": email, "password": password}
+    )
 
 
 def login_user(email: str = "user@example.com", password: str = "secret"):
-    return client.post("/login", json={"email": email, "password": password})
+    return client.post(
+        "/api-v1/auth/login", json={"email": email, "password": password}
+    )
 
 
 def forgot_password(email: str = "user@example.com"):
-    return client.post("/forgotpassword", json={"email": email})
+    return client.post("/api-v1/auth/forgotpassword", json={"email": email})
 
 
 def reset_password(token: str, new_password: str):
-    return client.post("/reset", json={"token": token, "new_password": new_password})
+    return client.post(
+        "/api-v1/auth/reset", json={"token": token, "new_password": new_password}
+    )
 
 
 def test_register_and_login(db_session):

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -3,7 +3,8 @@ from main import app
 
 client = TestClient(app)
 
+
 def test_health():
-    response = client.get("/health")
+    response = client.get("/api-v1/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -4,6 +4,7 @@ from backend.api.models.user import User
 
 client = TestClient(app)
 
+
 def create_user(db):
     user = User(email="user@example.com", hashed_password="pwd")
     db.add(user)
@@ -15,7 +16,7 @@ def create_user(db):
 def test_create_and_list_tasks(db_session):
     user = create_user(db_session)
     response = client.post(
-        "/v1/tasks",
+        "/api-v1/tasks",
         json={"title": "Test", "description": "desc"},
         headers={"X-User-Id": str(user.id)},
     )
@@ -24,7 +25,7 @@ def test_create_and_list_tasks(db_session):
     assert data["title"] == "Test"
     assert data["owner_id"] == user.id
 
-    resp = client.get("/v1/tasks", headers={"X-User-Id": str(user.id)})
+    resp = client.get("/api-v1/tasks", headers={"X-User-Id": str(user.id)})
     assert resp.status_code == 200
     tasks = resp.json()
     assert len(tasks) == 1
@@ -34,14 +35,14 @@ def test_create_and_list_tasks(db_session):
 def test_update_and_delete_task(db_session):
     user = create_user(db_session)
     create_resp = client.post(
-        "/v1/tasks",
+        "/api-v1/tasks",
         json={"title": "Task", "description": None},
         headers={"X-User-Id": str(user.id)},
     )
     task_id = create_resp.json()["id"]
 
     update_resp = client.patch(
-        f"/v1/tasks/{task_id}",
+        f"/api-v1/tasks/{task_id}",
         json={"title": "Updated"},
         headers={"X-User-Id": str(user.id)},
     )
@@ -49,10 +50,10 @@ def test_update_and_delete_task(db_session):
     assert update_resp.json()["title"] == "Updated"
 
     delete_resp = client.delete(
-        f"/v1/tasks/{task_id}", headers={"X-User-Id": str(user.id)}
+        f"/api-v1/tasks/{task_id}", headers={"X-User-Id": str(user.id)}
     )
     assert delete_resp.status_code == 200
 
-    list_resp = client.get("/v1/tasks", headers={"X-User-Id": str(user.id)})
+    list_resp = client.get("/api-v1/tasks", headers={"X-User-Id": str(user.id)})
     assert list_resp.status_code == 200
     assert list_resp.json() == []


### PR DESCRIPTION
## Summary
- Wrap auth, tasks, and health routers with `/api-v1/<domain>` prefixes
- Import all routers in `backend/api/routers/__init__.py` and include them via `main.py`
- Update tests to call versioned endpoints and allow config to ignore extra env vars

## Testing
- `DATABASE_URL=sqlite:// PYTHONPATH=. pytest -q` *(fails: The starlette.testclient module requires the httpx package to be installed)*
- `pip install httpx -q` *(fails: Could not find a version that satisfies the requirement httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68b70e54c31c83259da2d8bcf6896822