### PR TITLE
feat: add API client helper

### DIFF
--- a/frontend/pages/login.html
+++ b/frontend/pages/login.html
@@ -128,6 +128,7 @@
 
   <!--#include "partials/footer.html" -->
 
+  <script src="/js/apiClient.js"></script>
   <script>
     // --------- Utilidades UI
     const loginForm = document.getElementById('loginForm');

--- a/frontend/pages/register.html
+++ b/frontend/pages/register.html
@@ -198,6 +198,7 @@
 </main>
 
 <!--#include "partials/footer.html" -->
+<script src="/js/apiClient.js"></script>
 
 <!-- Modal PRO -->
 <div id="modalBackdrop" class="modal-backdrop"></div>

--- a/frontend/pages/tasks.html
+++ b/frontend/pages/tasks.html
@@ -31,6 +31,7 @@
 
 <!--#include "partials/footer.html" -->
 
+<script src="/js/apiClient.js"></script>
 <script>
   const box = document.getElementById('tasksBox');
   const form = document.getElementById('taskForm');

--- a/frontend/public/js/apiClient.js
+++ b/frontend/public/js/apiClient.js
@@ -1,0 +1,29 @@
+(function(global){
+  async function post(endpoint, data = {}) {
+    const deviceId = localStorage.getItem('deviceId');
+    const res = await fetch(`/api-v1/${endpoint}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...data, deviceId })
+    });
+
+    let body = null;
+    try {
+      body = await res.json();
+    } catch (_) {
+      // ignore json parse errors
+    }
+
+    if (!res.ok) {
+      const message = body && body.message ? body.message : 'Request failed';
+      const error = new Error(message);
+      error.status = res.status;
+      error.body = body;
+      throw error;
+    }
+
+    return body;
+  }
+
+  global.apiClient = { post };
+})(typeof window !== 'undefined' ? window : this);


### PR DESCRIPTION
## Summary
- add apiClient helper for POST requests with deviceId and JSON error handling
- load apiClient script on pages that perform API calls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `pytest` *(fails: ModuleNotFoundError: No module named 'backend')*


------
https://chatgpt.com/codex/tasks/task_e_68b70e5c3050832580cb95c6e9e39b1b