### PR TITLE
Add contact endpoint and tests

### DIFF
--- a/backend/api/routers/__init__.py
+++ b/backend/api/routers/__init__.py
@@ -1,6 +1,7 @@
 from .auth import router as auth_router
 from .health import router as health_router
 from .tasks import router as tasks_router
+from .contact import router as contact_router
 
-routers = [health_router, tasks_router, auth_router]
+routers = [health_router, tasks_router, auth_router, contact_router]
 

--- a/backend/api/routers/contact.py
+++ b/backend/api/routers/contact.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter
+from pydantic import BaseModel, EmailStr, constr
+
+router = APIRouter(prefix="/api-v1/contact", tags=["contact"])
+
+
+class ContactRequest(BaseModel):
+    name: constr(min_length=1)
+    email: EmailStr
+    message: constr(min_length=1)
+    device_id: constr(min_length=1)
+
+
+def send_email(name: str, email: str, message: str, device_id: str) -> None:
+    """Stub function to simulate sending an email."""
+    # In a real implementation, integrate with an email service here.
+    print(f"Email from {name} <{email}>: {message} (device {device_id})")
+
+
+@router.post("")
+def send_contact_form(contact: ContactRequest):
+    send_email(contact.name, contact.email, contact.message, contact.device_id)
+    return {"status": "ok"}

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -1,0 +1,28 @@
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+def test_contact_success():
+    payload = {
+        "name": "Alice",
+        "email": "alice@example.com",
+        "message": "Hello",
+        "device_id": "dev123",
+    }
+    response = client.post("/api-v1/contact", json=payload)
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_contact_validation_error():
+    payload = {
+        "name": "Bob",
+        "email": "not-an-email",
+        "message": "Hi",
+        "device_id": "dev321",
+    }
+    response = client.post("/api-v1/contact", json=payload)
+    assert response.status_code == 422
+    assert response.json() == {"status": 422, "message": "Validation Error"}


### PR DESCRIPTION
## Summary
- add contact router to handle incoming contact form submissions
- validate contact payload and stub email sending
- cover contact endpoint with tests

## Testing
- `pytest` *(fails: RuntimeError: The starlette.testclient module requires the httpx package to be installed)*
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx; tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b71b4ce48c8325bedd1d5cfbf20d5d