### PR TITLE
feat: add password reset flows and API login

### DIFF
--- a/frontend/pages/login.html
+++ b/frontend/pages/login.html
@@ -194,13 +194,10 @@
 
     // --------- Device Id
     function getDeviceId(){
-      const k = 'fixhub_device_id';
-      let id = localStorage.getItem(k);
+      let id = localStorage.getItem('deviceId');
       if (!id) {
-        id = ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
-          (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
-        );
-        localStorage.setItem(k, id);
+        id = self.crypto?.randomUUID ? self.crypto.randomUUID() : Math.random().toString(36).slice(2);
+        localStorage.setItem('deviceId', id);
       }
       return id;
     }
@@ -222,32 +219,23 @@
     loginForm.addEventListener('submit', async (e) => {
       e.preventDefault();
       if (throttled) return;
-      const username = document.getElementById('email').value.trim();
+      const email = document.getElementById('email').value.trim();
       const password = document.getElementById('password').value;
-      if (!username || !password){ showAlert('Introduce usuario y contraseña.'); return; }
+      if (!email || !password){ showAlert('Introduce email y contraseña.'); return; }
 
       throttled = true; submitBtn.disabled = true;
       setTimeout(() => { throttled = false; submitBtn.disabled = false; }, 4000);
 
       try {
-        const res = await fetch('/v1/auth/login', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ username, password, device: getDeviceId() })
-        });
-
-        if (res.status !== 200) {
-          showAlert(errMsg(res.status), 'Comprueba tus datos e inténtalo de nuevo.');
-          return;
-        }
-        const data = await res.json().catch(()=> ({}));
-        // Guardar lo que devuelva tu backend (tokens/jwt)
+        const deviceId = getDeviceId();
+        const data = await apiClient.post('auth/login', { email, password, deviceId });
+        if (data?.token)  localStorage.setItem('token', data.token);
         if (data?.tokens) localStorage.setItem('tokens', JSON.stringify(data.tokens));
         if (data?.user)   localStorage.setItem('user', JSON.stringify(data.user));
-        window.location.href = '/'; // o /pro.html si ya lo tienes
+        window.location.href = '/';
       } catch (err) {
         console.error(err);
-        showAlert('No se pudo conectar con el servidor.', 'Inténtalo de nuevo más tarde.');
+        showAlert(errMsg(err.status), err.message);
       }
     });
 

--- a/frontend/pages/request-password-reset.html
+++ b/frontend/pages/request-password-reset.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Solicitar restablecimiento</title>
+  <link rel="stylesheet" href="/css/style.css?v={cachebust}"/>
+  <script src="/js/apiClient.js"></script>
+</head>
+<body>
+  <!--#include "partials/header.html" -->
+  <main style="max-width:480px;margin:auto;padding:1rem;">
+    <h1>Recuperar contraseña</h1>
+    <form id="requestForm">
+      <label for="email">Email</label>
+      <input id="email" type="email" required class="input" />
+      <button type="submit" class="btn">Enviar enlace</button>
+    </form>
+    <div id="msg" class="hint" style="margin-top:1rem;"></div>
+  </main>
+  <!--#include "partials/footer.html" -->
+  <script>
+    const form = document.getElementById('requestForm');
+    const msg = document.getElementById('msg');
+
+    function ensureDeviceId(){
+      if (!localStorage.getItem('deviceId')) {
+        const newId = self.crypto?.randomUUID ? self.crypto.randomUUID() : Math.random().toString(36).slice(2);
+        localStorage.setItem('deviceId', newId);
+      }
+    }
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      ensureDeviceId();
+      msg.textContent = '';
+      const email = document.getElementById('email').value.trim();
+      try {
+        await apiClient.post('auth/request-password-reset', { email });
+        msg.textContent = 'Si existe una cuenta, se enviará un correo con instrucciones.';
+      } catch (err) {
+        console.error(err);
+        msg.textContent = err.message || 'No se pudo procesar la solicitud.';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/frontend/pages/reset-password.html
+++ b/frontend/pages/reset-password.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Restablecer contraseña</title>
+  <link rel="stylesheet" href="/css/style.css?v={cachebust}"/>
+  <script src="/js/apiClient.js"></script>
+</head>
+<body>
+  <!--#include "partials/header.html" -->
+  <main style="max-width:480px;margin:auto;padding:1rem;">
+    <h1>Restablecer contraseña</h1>
+    <form id="resetForm">
+      <label for="token">Token</label>
+      <input id="token" required class="input" />
+      <label for="password">Nueva contraseña</label>
+      <input id="password" type="password" required class="input" />
+      <button type="submit" class="btn">Restablecer</button>
+    </form>
+    <div id="msg" class="hint" style="margin-top:1rem;"></div>
+  </main>
+  <!--#include "partials/footer.html" -->
+  <script>
+    const form = document.getElementById('resetForm');
+    const msg = document.getElementById('msg');
+
+    function ensureDeviceId(){
+      if (!localStorage.getItem('deviceId')) {
+        const newId = self.crypto?.randomUUID ? self.crypto.randomUUID() : Math.random().toString(36).slice(2);
+        localStorage.setItem('deviceId', newId);
+      }
+    }
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      ensureDeviceId();
+      msg.textContent = '';
+      const token = document.getElementById('token').value.trim();
+      const newPassword = document.getElementById('password').value;
+      try {
+        await apiClient.post('auth/reset-password', { token, newPassword });
+        msg.textContent = 'Contraseña restablecida correctamente.';
+      } catch (err) {
+        console.error(err);
+        msg.textContent = err.message || 'No se pudo restablecer la contraseña.';
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- use apiClient helper for login and store returned token
- add request-password-reset and reset-password pages with API integration

## Testing
- `pytest` *(fails: The starlette.testclient module requires the httpx package to be installed)*
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx (proxy error))*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b71c9e8c148325b2dec29c060921ba