### PR TITLE
Use versioned API prefix in tests and cover contact endpoint

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,6 +6,9 @@ from backend.api.models.user import User
 
 client = TestClient(app)
 
+# All authentication endpoints are served under a versioned API prefix.
+API_PREFIX = "/api-v1"
+
 
 def register_user(
     email: str = "user@example.com",
@@ -31,7 +34,7 @@ def register_user(
         "terms_accepted": True,
         "device_id": device_id,
     }
-    return client.post("/api-v1/auth/register", json=payload)
+    return client.post(f"{API_PREFIX}/auth/register", json=payload)
 
 
 def login_user(
@@ -40,20 +43,20 @@ def login_user(
     device_id: str = "device_login",
 ):
     return client.post(
-        "/api-v1/auth/login",
+        f"{API_PREFIX}/auth/login",
         json={"email": email, "password": password, "device_id": device_id},
     )
 
 
 def forgot_password(email: str = "user@example.com", device_id: str = "device_forgot"):
     return client.post(
-        "/api-v1/auth/forgotpassword", json={"email": email, "device_id": device_id}
+        f"{API_PREFIX}/auth/forgotpassword", json={"email": email, "device_id": device_id}
     )
 
 
 def reset_password(token: str, new_password: str, device_id: str = "device_forgot"):
     return client.post(
-        "/api-v1/auth/reset",
+        f"{API_PREFIX}/auth/reset",
         json={"token": token, "new_password": new_password, "device_id": device_id},
     )
 

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -1,19 +1,37 @@
 from fastapi.testclient import TestClient
 from main import app
+from backend.api.routers import contact as contact_router
 
 client = TestClient(app)
 
+# Base prefix for all versioned API routes.
+API_PREFIX = "/api-v1"
 
-def test_contact_success():
+
+def test_contact_success(monkeypatch):
     payload = {
         "name": "Alice",
         "email": "alice@example.com",
         "message": "Hello",
         "device_id": "dev123",
     }
-    response = client.post("/api-v1/contact", json=payload)
+
+    called = {}
+
+    def fake_send_email(name, email, message, device_id):
+        called["args"] = (name, email, message, device_id)
+
+    monkeypatch.setattr(contact_router, "send_email", fake_send_email)
+
+    response = client.post(f"{API_PREFIX}/contact", json=payload)
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+    assert called["args"] == (
+        "Alice",
+        "alice@example.com",
+        "Hello",
+        "dev123",
+    )
 
 
 def test_contact_validation_error():
@@ -23,6 +41,17 @@ def test_contact_validation_error():
         "message": "Hi",
         "device_id": "dev321",
     }
-    response = client.post("/api-v1/contact", json=payload)
+    response = client.post(f"{API_PREFIX}/contact", json=payload)
+    assert response.status_code == 422
+    assert response.json() == {"status": 422, "message": "Validation Error"}
+
+
+def test_contact_missing_device_id():
+    payload = {
+        "name": "Eve",
+        "email": "eve@example.com",
+        "message": "Hi",
+    }
+    response = client.post(f"{API_PREFIX}/contact", json=payload)
     assert response.status_code == 422
     assert response.json() == {"status": 422, "message": "Validation Error"}

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -3,8 +3,10 @@ from main import app
 
 client = TestClient(app)
 
+API_PREFIX = "/api-v1"
+
 
 def test_health():
-    response = client.get("/api-v1/health")
+    response = client.get(f"{API_PREFIX}/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -4,6 +4,9 @@ from backend.api.models.user import User
 
 client = TestClient(app)
 
+# Versioned API prefix used for all task endpoints.
+API_PREFIX = "/api-v1"
+
 
 def create_user(db):
     user = User(email="user@example.com", hashed_password="pwd")
@@ -16,7 +19,7 @@ def create_user(db):
 def test_create_and_list_tasks(db_session):
     user = create_user(db_session)
     response = client.post(
-        "/api-v1/tasks",
+        f"{API_PREFIX}/tasks",
         json={"title": "Test", "description": "desc"},
         headers={"X-User-Id": str(user.id)},
     )
@@ -25,7 +28,7 @@ def test_create_and_list_tasks(db_session):
     assert data["title"] == "Test"
     assert data["owner_id"] == user.id
 
-    resp = client.get("/api-v1/tasks", headers={"X-User-Id": str(user.id)})
+    resp = client.get(f"{API_PREFIX}/tasks", headers={"X-User-Id": str(user.id)})
     assert resp.status_code == 200
     tasks = resp.json()
     assert len(tasks) == 1
@@ -35,14 +38,14 @@ def test_create_and_list_tasks(db_session):
 def test_update_and_delete_task(db_session):
     user = create_user(db_session)
     create_resp = client.post(
-        "/api-v1/tasks",
+        f"{API_PREFIX}/tasks",
         json={"title": "Task", "description": None},
         headers={"X-User-Id": str(user.id)},
     )
     task_id = create_resp.json()["id"]
 
     update_resp = client.patch(
-        f"/api-v1/tasks/{task_id}",
+        f"{API_PREFIX}/tasks/{task_id}",
         json={"title": "Updated"},
         headers={"X-User-Id": str(user.id)},
     )
@@ -50,10 +53,10 @@ def test_update_and_delete_task(db_session):
     assert update_resp.json()["title"] == "Updated"
 
     delete_resp = client.delete(
-        f"/api-v1/tasks/{task_id}", headers={"X-User-Id": str(user.id)}
+        f"{API_PREFIX}/tasks/{task_id}", headers={"X-User-Id": str(user.id)}
     )
     assert delete_resp.status_code == 200
 
-    list_resp = client.get("/api-v1/tasks", headers={"X-User-Id": str(user.id)})
+    list_resp = client.get(f"{API_PREFIX}/tasks", headers={"X-User-Id": str(user.id)})
     assert list_resp.status_code == 200
     assert list_resp.json() == []


### PR DESCRIPTION
## Summary
- use API v1 prefix constant across tests
- add tests for contact endpoint and device ID validation

## Testing
- `pytest -q` *(fails: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b721f9be248325aa69739234df9587