### PR TITLE
Add pricing API and client utilities

### DIFF
--- a/backend/api/routers/__init__.py
+++ b/backend/api/routers/__init__.py
@@ -2,6 +2,7 @@ from .auth import router as auth_router
 from .health import router as health_router
 from .tasks import router as tasks_router
 from .contact import router as contact_router
+from .pricing import router as pricing_router
 
-routers = [health_router, tasks_router, auth_router, contact_router]
+routers = [health_router, tasks_router, auth_router, contact_router, pricing_router]
 

--- a/backend/api/routers/pricing.py
+++ b/backend/api/routers/pricing.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/api-v1/pricing", tags=["pricing"])
+
+PRICING_DATA = {
+    "currency": "EUR",
+    "vatIncluded": False,
+    "annualDiscount": 0.10,
+    "solo": {"monthly": 49},
+    "team": {
+        "tiers": [
+            {"maxSeats": 1, "price": 45},
+            {"maxSeats": 2, "price": 45},
+            {"maxSeats": 3, "price": 35},
+            {"maxSeats": 4, "price": 33},
+            {"maxSeats": 5, "price": 30},
+            {"maxSeats": 6, "price": 28},
+            {"maxSeats": 7, "price": 27},
+            {"maxSeats": 99, "price": 27},
+        ]
+    },
+}
+
+
+@router.get("")
+def get_pricing():
+    return PRICING_DATA
+

--- a/frontend/pages/pricing.html
+++ b/frontend/pages/pricing.html
@@ -191,7 +191,30 @@
 
 <!--#include "partials/footer.html" -->
 
-<script>
+<script type="module">
+import { pricePerSeatFromTiers, computeAnnual } from '/js/pricing-lib.js';
+
+  let PRICING = null;
+  async function loadPricing(){
+    try{
+      const res = await fetch('/api-v1/pricing');
+      if(!res.ok) throw 0;
+      PRICING = await res.json();
+    }catch(e){
+      PRICING = {
+        currency:'EUR', vatIncluded:false, annualDiscount:0.10,
+        solo:{ monthly:49 },
+        team:{ tiers:[
+          {maxSeats:1,price:45},{maxSeats:2,price:45},{maxSeats:3,price:35},
+          {maxSeats:4,price:33},{maxSeats:5,price:30},{maxSeats:6,price:28},
+          {maxSeats:7,price:27},{maxSeats:99,price:27}
+        ]}
+      };
+    }
+  }
+
+  await loadPricing();
+
   // ---- Constantes toggle ----
   const MONTHLY = 'monthly';
   const YEARLY  = 'yearly';
@@ -207,7 +230,7 @@
   const freeBtn    = document.getElementById('freeBtn');
 
   // ---- SOLO ----
-  const soloMonthly = 49;
+  let soloMonthly = PRICING.solo.monthly;
   const soloPriceEl  = document.getElementById('soloPrice');
   const soloPeriodEl = document.getElementById('soloPeriod');
 
@@ -219,18 +242,11 @@
 
   // Precio por asiento mensual (según tamaño)
   function perSeatPrice(n){
-    if(n <= 1) return 45;
-    if(n == 2) return 45;
-    if(n == 3) return 35;
-    if(n == 4) return 33;
-    if(n == 5) return 30;
-    if(n == 6) return 28;
-    if(n == 7) return 27;
-    return 27;
+    return pricePerSeatFromTiers(n, PRICING.team.tiers);
   }
 
   // Helpers
-  function yearlyTotal(monthly){ return monthly * 12 * 0.9 } // -10%
+  function yearlyTotal(monthly){ return computeAnnual(monthly, PRICING.annualDiscount).yearly }
   function fmt(n){ const v = Number(n); return (v%1===0)? v.toString() : v.toFixed(2).replace('.', ',') }
 
   // --- Actualiza FREE (disabled en anual) ---
@@ -272,9 +288,10 @@
       teamPeriodEl.textContent = '/ mes*';
       teamNoteEl.innerHTML = 'Precio por persona: <strong>'+fmt(seat)+'€</strong>';
     } else {
-      teamPriceNum.textContent = fmt(yearlyTotal(mTotal));
+      const { yearly } = computeAnnual(mTotal, PRICING.annualDiscount);
+      teamPriceNum.textContent = fmt(yearly);
       teamPeriodEl.textContent = '/ año*';
-      teamNoteEl.innerHTML = 'Equivale a <strong>'+fmt(seat*0.9)+'€</strong> / persona / mes (−10% anual).';
+      teamNoteEl.innerHTML = 'Equivale a <strong>'+fmt(seat*(1-PRICING.annualDiscount))+'€</strong> / persona / mes (−'+(PRICING.annualDiscount*100)+'% anual).';
     }
   }
 

--- a/frontend/pages/team.html
+++ b/frontend/pages/team.html
@@ -162,10 +162,33 @@
     </div>
   </div>
 
-<script>
+<script type="module">
+import { formatEUR, computeTeamMonthly } from '/js/pricing-lib.js';
+
 /* ====== Config ====== */
 const API_PREFIX = '/api-v1'; // <-- requerido
 const token = localStorage.getItem('token') || '';
+
+let PRICING = null;
+async function loadPricing(){
+  try{
+    const res = await fetch('/api-v1/pricing');
+    if(!res.ok) throw 0;
+    PRICING = await res.json();
+  }catch(e){
+    PRICING = {
+      currency:'EUR', vatIncluded:false, annualDiscount:0.10,
+      solo:{ monthly:49 },
+      team:{ tiers:[
+        {maxSeats:1,price:45},{maxSeats:2,price:45},{maxSeats:3,price:35},
+        {maxSeats:4,price:33},{maxSeats:5,price:30},{maxSeats:6,price:28},
+        {maxSeats:7,price:27},{maxSeats:99,price:27}
+      ]}
+    };
+  }
+}
+
+await loadPricing();
 
 /* ====== Header/Footer includes ====== */
 (async function mountHF(){
@@ -191,18 +214,7 @@ function authHeaders() {
   if (token) h['Authorization'] = 'Bearer ' + token;
   return h;
 }
-function perSeatPrice(n){
-  n = Number(n);
-  if (n <= 1) return 45;
-  if (n === 2) return 45;
-  if (n === 3) return 35;
-  if (n === 4) return 33;
-  if (n === 5) return 30;
-  if (n === 6) return 28;
-  if (n === 7) return 27;
-  return 27;
-}
-function fmtEUR(x){ return new Intl.NumberFormat('es-ES',{style:'currency',currency:'EUR'}).format(x); }
+function fmtEUR(x){ return formatEUR(x); }
 function show(el){ el.style.display='grid'; el.removeAttribute('aria-hidden'); }
 function hide(el){ el.style.display='none'; el.setAttribute('aria-hidden','true'); }
 
@@ -371,15 +383,14 @@ function refreshPriceSummary(){
   const plan = $('mPlan').value;
   let text = '';
   if (plan === 'Solo') {
-    text = 'Plan Solo: tarifa única de 49 €/mes (*IVA no incluido).';
+    text = `Plan Solo: tarifa única de ${fmtEUR(PRICING.solo.monthly)} /mes (*IVA no incluido).`;
   } else {
     const n = Number($('mTeamSize').value);
-    const seat = perSeatPrice(n);
-    const total = seat * n;
+    const { seat, total } = computeTeamMonthly(n, PRICING.team.tiers);
     text = `Plan Team para ${n} persona${n>1?'s':''}: ${fmtEUR(seat)} por persona · Total estimado: ${fmtEUR(total)} al mes (*IVA no incluido).`;
     if (org.plan==='Team' && org.teamMembers){
-      const old = perSeatPrice(org.teamMembers) * org.teamMembers;
-      const delta = total - old;
+      const { total: oldTotal } = computeTeamMonthly(org.teamMembers, PRICING.team.tiers);
+      const delta = total - oldTotal;
       text += ` ${delta===0?'(sin cambios)':'Cambio mensual: ' + (delta>0?'+':'') + fmtEUR(delta)}`;
     }
   }
@@ -415,7 +426,7 @@ $('btnAdd').addEventListener('click', ()=> openMember(null));
 $('btnRefresh').addEventListener('click', loadTeam);
 
 /* ====== Init ====== */
-(async function init(){
+ (async function init(){
   await loadOrg();
   await loadTeam();
 })();

--- a/frontend/public/js/pricing-lib.js
+++ b/frontend/public/js/pricing-lib.js
@@ -1,0 +1,17 @@
+// /public/js/pricing-lib.js
+export function formatEUR(x){ return new Intl.NumberFormat('es-ES',{style:'currency',currency:'EUR'}).format(x); }
+
+export function pricePerSeatFromTiers(n, tiers){
+  for (const t of tiers) if (n <= t.maxSeats) return t.price;
+  return tiers[tiers.length - 1].price;
+}
+
+export function computeTeamMonthly(n, tiers){ 
+  const seat = pricePerSeatFromTiers(n, tiers);
+  return { seat, total: seat * n };
+}
+
+export function computeAnnual(totalMonthly, annualDiscount){ 
+  const yearly = totalMonthly * 12 * (1 - annualDiscount); 
+  return { yearly, monthlyEq: yearly / 12 };
+}

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+API_PREFIX = "/api-v1"
+
+
+def test_pricing_endpoint():
+    response = client.get(f"{API_PREFIX}/pricing")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["currency"] == "EUR"
+    assert "solo" in data and "team" in data
+    assert isinstance(data["team"]["tiers"], list) and len(data["team"]["tiers"]) > 0


### PR DESCRIPTION
## Summary
- expose `/api-v1/pricing` endpoint with static pricing data
- add reusable pricing-lib utilities for currency formatting and tier calculations
- update pricing and team pages to fetch pricing data with local fallback
- cover pricing API with tests

## Testing
- `pytest` *(fails: The starlette.testclient module requires the httpx package to be installed)*
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68b731f7fd988325a7d998c51f80fef2