### PR TITLE
Use environment-based auth settings

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,4 @@ POSTGRES_USER=tradex
 POSTGRES_PASSWORD=tradex
 POSTGRES_DB=tradex
 DATABASE_URL=postgresql://tradex:tradex@db:5432/tradex
+SECRET_KEY=changeme

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -4,6 +4,9 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     app_name: str = "Tradex"
     database_url: str = "sqlite:///./sql_app.db"
+    secret_key: str = "changeme"
+    algorithm: str = "HS256"
+    access_token_expire_minutes: int = 30
 
     class Config:
         env_file = ".env"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,7 +1,7 @@
 from fastapi.testclient import TestClient
 from jose import jwt
 from main import app
-from backend.api.routers.auth import SECRET_KEY, ALGORITHM
+from backend.core.config import settings
 from backend.api.models.user import User
 
 client = TestClient(app)
@@ -68,7 +68,7 @@ def test_register_and_login(db_session):
     response = register_user(device_id=register_device)
     assert response.status_code == 200
     token = response.json()["access_token"]
-    payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
     assert payload["device_id"] == register_device
     user = db_session.query(User).filter(User.email == "user@example.com").first()
     assert user.device_id == register_device
@@ -79,7 +79,7 @@ def test_register_and_login(db_session):
     response = login_user(device_id=login_device)
     assert response.status_code == 200
     token = response.json()["access_token"]
-    payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
     assert payload["device_id"] == login_device
     user = db_session.query(User).filter(User.email == "user@example.com").first()
     assert user.device_id == login_device
@@ -101,7 +101,7 @@ def test_forgot_and_reset(db_session):
     response = forgot_password(device_id=forgot_device)
     assert response.status_code == 200
     token = response.json()["reset_token"]
-    payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
     assert payload["device_id"] == forgot_device
     user = db_session.query(User).filter(User.email == "user@example.com").first()
     assert user.device_id == forgot_device
@@ -115,7 +115,9 @@ def test_forgot_and_reset(db_session):
     new_login_device = "device_new_login"
     response = login_user(password="newsecret", device_id=new_login_device)
     assert response.status_code == 200
-    payload = jwt.decode(response.json()["access_token"], SECRET_KEY, algorithms=[ALGORITHM])
+    payload = jwt.decode(
+        response.json()["access_token"], settings.secret_key, algorithms=[settings.algorithm]
+    )
     assert payload["device_id"] == new_login_device
     user = db_session.query(User).filter(User.email == "user@example.com").first()
     assert user.device_id == new_login_device


### PR DESCRIPTION
## Summary
- configure JWT auth settings via environment variables
- use shared settings in auth router and tests
- add SECRET_KEY placeholder to env file

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68b843f5967c8325b65af9c7c83b4a87