### PR TITLE
feat: centralize db session dependency

### DIFF
--- a/backend/api/dependencies.py
+++ b/backend/api/dependencies.py
@@ -4,19 +4,11 @@ from jose import JWTError, jwt
 from sqlalchemy.orm import Session
 
 from backend.core.config import settings
-from backend.core.database import SessionLocal
+from backend.core.deps import get_db
 from backend.api.models.user import User
 
 
 oauth2_scheme = HTTPBearer()
-
-
-def get_db():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
 
 
 def get_current_user(

--- a/backend/api/routers/auth.py
+++ b/backend/api/routers/auth.py
@@ -7,21 +7,13 @@ from sqlalchemy.orm import Session
 from passlib.context import CryptContext
 from jose import JWTError, jwt
 
-from backend.core.database import SessionLocal
 from backend.api.models.user import User
 from backend.core.config import settings
+from backend.core.deps import get_db
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 router = APIRouter(prefix="/api-v1/auth")
-
-
-def get_db():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
 
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:

--- a/backend/api/routers/tasks.py
+++ b/backend/api/routers/tasks.py
@@ -6,7 +6,8 @@ from sqlalchemy.orm import Session
 from backend.api.models.task import Task
 from backend.api.models.user import User
 from backend.api.schemas import TaskCreate, TaskUpdate, TaskRead
-from backend.api.dependencies import get_db, get_current_user
+from backend.api.dependencies import get_current_user
+from backend.core.deps import get_db
 
 router = APIRouter(prefix="/api-v1/tasks", tags=["tasks"])
 

--- a/backend/core/deps.py
+++ b/backend/core/deps.py
@@ -1,0 +1,14 @@
+from typing import Generator
+
+from sqlalchemy.orm import Session
+
+from .database import SessionLocal
+
+
+def get_db() -> Generator[Session, None, None]:
+    """Yield a database session for use in request handlers."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- add shared `get_db` dependency in `backend/core/deps.py`
- refactor routers to import the shared database dependency
- use shared `get_db` for authentication helpers

## Testing
- `pytest -q` *(fails: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b86e7d23b88325a778c0705370c103