### PR TITLE
Refine settings page UI

### DIFF
--- a/frontend/pages/settings.html
+++ b/frontend/pages/settings.html
@@ -14,28 +14,29 @@
     @keyframes spin { to { transform: rotate(360deg) } }
     .preview-box { border:1px dashed var(--border); border-radius:12px; min-height:140px; display:grid; place-items:center; color:var(--muted);}
     .toolbar-right { display:flex; gap:.5rem; align-items:center; margin-left:auto; }
-    .row { display:flex; gap: var(--s4); align-items:flex-end; flex-wrap:wrap; }
+    .row { display:flex; gap: var(--s4); align-items:center; flex-wrap:wrap; }
     .w240{ width:240px; }
   </style>
 </head>
 <body>
 <!--#include "partials/header.html" -->
 
-<main class="layout">
+<main>
+  <h2>Configuración</h2>
   <section class="grid">
 
     <!-- IA y presets -->
     <article id="ia" class="card">
       <div class="section-head">
-        <h3 style="margin:0;">IA y presets</h3>
+        <h3 style="margin:0;">🤖 IA y presets</h3>
         <span class="hint-right">Sube mínimo 3 presupuestos previos</span>
       </div>
 
       <div class="row">
-        <label class="w240">
+        <div class="w240">
           <span>Subir archivo(s)</span>
-          <input id="aiFiles" type="file" multiple />
-        </label>
+          <label id="aiDrop" class="drop-zone">Arrastra o haz clic<input id="aiFiles" type="file" multiple></label>
+        </div>
 
         <button id="btnUploadAI" class="btn secondary">Subir archivo</button>
 
@@ -43,20 +44,20 @@
           <span>Subidos</span><strong id="aiUploaded">0</strong>
           <label class="inline">Estado:
             <select id="aiStatus" class="input">
-              <option value="idle">Idle</option>
-              <option value="processing">Procesando</option>
-              <option value="ok">OK</option>
-              <option value="error">Error</option>
+              <option value="idle">Sin entrenar</option>
+              <option value="processing">⏳ Procesando…</option>
+              <option value="ok">✅ OK</option>
+              <option value="error">❌ Error</option>
             </select>
           </label>
         </div>
 
         <div class="toolbar-right">
-          <button id="btnTrain" class="btn secondary">
+          <button id="btnTrain" class="btn primary">
             <span class="chip">⚙️</span> Entrenar IA
           </button>
-          <button id="btnResetAI" class="btn">Resetear</button>
-          <button id="btnDownloadModel" class="btn">Descargar modelo</button>
+          <button id="btnResetAI" class="btn danger">Resetear</button>
+          <button id="btnDownloadModel" class="btn secondary">Descargar modelo</button>
         </div>
       </div>
       <div id="trainHint" class="hint" style="margin-top:.6rem; display:none;">
@@ -66,7 +67,7 @@
 
     <!-- Tarifas y márgenes -->
     <article id="tarifas" class="card">
-      <h3 style="margin-top:0;">Tarifas y márgenes</h3>
+      <h3 style="margin-top:0;">⚙️ Tarifas y márgenes</h3>
 
       <div class="grid" style="grid-template-columns: repeat(3, 1fr);">
         <label>€/hora <input id="rateHour" class="input" type="number" placeholder="45" step="1"></label>
@@ -83,19 +84,24 @@
           </select>
         </label>
 
-        <label>Markup materiales (%) <input id="markup" class="input" type="number" placeholder="20" step="1"></label>
-        <label>IVA (%) <input id="vat" class="input" type="number" placeholder="21" step="1"></label>
-        <label>Coste desplazamiento (€/km) <input id="travelKm" class="input" type="number" placeholder="0.5" step="0.1"></label>
+        <details class="advanced" style="grid-column:1/-1; margin-top:var(--s3);">
+          <summary>Opciones avanzadas</summary>
+          <div class="grid" style="grid-template-columns: repeat(3, 1fr); margin-top:var(--s3);">
+            <label title="% extra aplicado al coste">Markup materiales (%) <input id="markup" class="input" type="number" placeholder="20" step="1"></label>
+            <label title="Impuesto sobre el valor añadido">IVA (%) <input id="vat" class="input" type="number" placeholder="21" step="1"></label>
+            <label title="Coste por kilómetro recorrido">Coste desplazamiento (€/km) <input id="travelKm" class="input" type="number" placeholder="0.5" step="0.1"></label>
+          </div>
+        </details>
       </div>
 
       <div class="toolbar" style="justify-content:flex-end; margin-top: var(--s3);">
-        <button id="btnSaveTariffs" class="btn">Guardar</button>
+        <button id="btnSaveTariffs" class="btn primary">Guardar</button>
       </div>
     </article>
 
     <!-- Proveedores -->
     <article id="proveedor" class="card">
-      <h3>Proveedores</h3>
+      <h3>🛒 Proveedores</h3>
       <div class="row">
         <label class="w240">
           <span>Proveedor por defecto</span>
@@ -112,48 +118,49 @@
           <input id="otherProvider" class="input" placeholder="Nombre"/>
         </label>
 
-        <label class="w240">
+        <div class="w240">
           <span>Subir catálogo</span>
-          <input id="providerCatalog" type="file" />
-        </label>
+          <label id="catalogDrop" class="drop-zone">Arrastra o haz clic<input id="providerCatalog" type="file"></label>
+        </div>
 
-        <button id="btnUploadCatalog" class="btn">Subir archivo</button>
+        <button id="btnUploadCatalog" class="btn secondary">Subir archivo</button>
 
         <div class="inline">
           <span>Estado:</span>
-          <input id="catalogStatus" class="input" value="procesando..." style="width:160px" />
+          <input id="catalogStatus" class="input" value="⏳ Procesando…" style="width:160px" />
         </div>
 
         <div class="toolbar-right">
-          <button id="btnSaveProvider" class="btn">Guardar</button>
+          <button id="btnSaveProvider" class="btn primary">Guardar</button>
         </div>
       </div>
     </article>
 
     <!-- Documentación y prefijos -->
     <article id="prefijos" class="card">
-      <h3>Documentación y prefijos</h3>
-      <div class="grid" style="grid-template-columns: repeat(2, 1fr);">
-        <div class="grid" style="grid-template-columns: repeat(3, 1fr);">
-          <label>Presupuestos <input id="prefQuote" class="input" placeholder="PRES-2025-"/></label>
-          <label>Facturas <input id="prefInvoice" class="input" placeholder="FACT-"/></label>
-          <label>Partes <input id="prefWork" class="input" placeholder="PAR-"/></label>
-        </div>
-        <div class="grid" style="grid-template-columns: repeat(3, 1fr);">
+      <h3>📑 Documentación y prefijos</h3>
+      <div class="grid" style="grid-template-columns: repeat(3, 1fr);">
+        <label>Presupuestos <input id="prefQuote" class="input" placeholder="PRES-2025-"/></label>
+        <label>Facturas <input id="prefInvoice" class="input" placeholder="FACT-"/></label>
+        <label>Partes <input id="prefWork" class="input" placeholder="PAR-"/></label>
+      </div>
+      <details class="advanced" style="margin-top:var(--s3);">
+        <summary>Opciones avanzadas</summary>
+        <div class="grid" style="grid-template-columns: repeat(3, 1fr); margin-top:var(--s3);">
           <label>Reset contador Presupuestos <input id="resetQuote" class="input" type="number" placeholder="1"/></label>
           <label>Reset contador Facturas <input id="resetInvoice" class="input" type="number" placeholder="1"/></label>
           <label>Reset contador Partes <input id="resetWork" class="input" type="number" placeholder="1"/></label>
         </div>
-      </div>
+      </details>
       <p class="hint">El siguiente número se recalculará automáticamente al guardar.</p>
       <div class="toolbar" style="justify-content:flex-end;">
-        <button id="btnSavePrefixes" class="btn">Guardar</button>
+        <button id="btnSavePrefixes" class="btn primary">Guardar</button>
       </div>
     </article>
 
     <!-- Datos fiscales -->
     <article id="fiscal" class="card">
-      <h3>Datos fiscales</h3>
+      <h3>🧾 Datos fiscales</h3>
       <div class="grid" style="grid-template-columns: repeat(2, 1fr);">
         <label>Nombre fiscal <input id="taxName" class="input" /></label>
         <label>NIF/CIF <input id="taxId" class="input" /></label>
@@ -161,16 +168,17 @@
         <label>Ciudad / CP <input id="taxCityZip" class="input" /></label>
       </div>
       <div class="toolbar" style="justify-content:flex-end;">
-        <button id="btnSaveFiscal" class="btn">Guardar</button>
+        <button id="btnSaveFiscal" class="btn primary">Guardar</button>
       </div>
     </article>
 
     <!-- Branding -->
     <article id="branding" class="card">
-      <h3>Branding de documentos</h3>
+      <h3>🎨 Branding de documentos</h3>
       <div class="grid" style="grid-template-columns: 1fr 1fr;">
         <div class="wire" style="padding:12px;">
-          <label>Logo <input id="logoFile" type="file" accept="image/*"/></label>
+          <span>Logo</span>
+          <label id="logoDrop" class="drop-zone" style="margin-top:.6rem;">Arrastra o haz clic<input id="logoFile" type="file" accept="image/*"></label>
           <div id="logoPreview" class="preview-box" style="margin-top:.6rem;">
             <span>Vista previa</span>
           </div>
@@ -187,8 +195,8 @@
             <option value="B">Modelo B</option>
           </select>
           <div class="toolbar" style="justify-content:flex-end; margin-top: var(--s3);">
-            <button id="btnSaveBranding" class="btn">Guardar</button>
-            <button id="btnPreviewBrand" class="btn secondary">preview</button>
+            <button id="btnSaveBranding" class="btn primary">Guardar</button>
+            <button id="btnPreviewBrand" class="btn secondary">Preview</button>
           </div>
         </div>
       </div>
@@ -196,12 +204,12 @@
 
     <!-- Modelo de email -->
     <article id="email" class="card">
-      <h3>Modelo de email</h3>
+      <h3>✉️ Modelo de email</h3>
       <label>Asunto <input id="emailSubject" class="input" placeholder="Tu presupuesto {numero}"/></label>
       <label style="margin-top:.6rem;">Cuerpo</label>
       <textarea id="emailBody" class="input" placeholder="Hola {cliente}, adjuntamos tu presupuesto por importe {importe}. Enlace: {enlace}"></textarea>
       <div class="toolbar" style="justify-content:flex-end; margin-top: var(--s3);">
-        <button id="btnSaveEmail" class="btn">Guardar</button>
+        <button id="btnSaveEmail" class="btn primary">Guardar</button>
       </div>
       <p class="hint">Variables disponibles: {cliente}, {importe}, {enlace}, {numero}.</p>
     </article>
@@ -214,12 +222,20 @@
 <script>
 const API = location.origin.replace(/\/$/, ''); // adjust if FE+BE on different hosts
 
+// Format minutes as m' or h h'
+function fmtMinutes(m){
+  if(m < 60) return `${m}'`;
+  const h = Math.floor(m/60);
+  const min = m % 60;
+  return min ? `${h}h ${min}'` : `${h}h`;
+}
+
 // Fill 5' steps (5..120)
 function fillSteps(sel){
   sel.innerHTML='';
   for(let m=5;m<=120;m+=5){
     const o=document.createElement('option');
-    o.value=m; o.textContent=`${m}'`;
+    o.value=m; o.textContent=fmtMinutes(m);
     sel.appendChild(o);
   }
 }
@@ -227,6 +243,33 @@ function fillSteps(sel){
 const minBlock = document.getElementById('minBlock');
 const stepBlock = document.getElementById('stepBlock');
 fillSteps(minBlock); fillSteps(stepBlock);
+
+// drop zones
+const aiFiles = document.getElementById('aiFiles');
+const catalogInput = document.getElementById('providerCatalog');
+const logoFile = document.getElementById('logoFile');
+
+function bindDropZone(zone, input){
+  zone.addEventListener('click', () => input.click());
+  zone.addEventListener('dragover', e => { e.preventDefault(); zone.classList.add('hover'); });
+  zone.addEventListener('dragleave', () => zone.classList.remove('hover'));
+  zone.addEventListener('drop', e => { e.preventDefault(); input.files = e.dataTransfer.files; zone.classList.remove('hover'); input.dispatchEvent(new Event('change')); });
+}
+
+const aiDrop = document.getElementById('aiDrop');
+bindDropZone(aiDrop, aiFiles);
+aiFiles.addEventListener('change', () => {
+  aiDrop.textContent = aiFiles.files.length ? `${aiFiles.files.length} archivo(s)` : 'Arrastra o haz clic';
+});
+
+const catalogDrop = document.getElementById('catalogDrop');
+bindDropZone(catalogDrop, catalogInput);
+catalogInput.addEventListener('change', () => {
+  catalogDrop.textContent = catalogInput.files[0]?.name || 'Arrastra o haz clic';
+});
+
+const logoDrop = document.getElementById('logoDrop');
+bindDropZone(logoDrop, logoFile);
 
 // Provider "other"
 const provider = document.getElementById('provider');
@@ -236,9 +279,9 @@ provider.addEventListener('change', () => {
 });
 
 // Branding preview
-const logoFile = document.getElementById('logoFile');
 const logoPreview = document.getElementById('logoPreview');
 logoFile.addEventListener('change', () => {
+  logoDrop.textContent = logoFile.files[0]?.name || 'Arrastra o haz clic';
   const f = logoFile.files[0]; if(!f) return;
   const reader = new FileReader();
   reader.onload = e => {
@@ -248,7 +291,6 @@ logoFile.addEventListener('change', () => {
 });
 
 // ---- IA actions
-const aiFiles = document.getElementById('aiFiles');
 const aiUploaded = document.getElementById('aiUploaded');
 const btnUploadAI = document.getElementById('btnUploadAI');
 const btnTrain = document.getElementById('btnTrain');
@@ -263,6 +305,7 @@ btnUploadAI.onclick = async () => {
   const r = await fetch(`${API}/settings/ai/uploads`, { method:'POST', body: fd });
   const j = await r.json();
   aiUploaded.textContent = j.count ?? 0;
+  alert('✅ Archivos subidos');
 };
 
 btnTrain.onclick = async () => {
@@ -296,6 +339,7 @@ async function saveJSON(url, payload){
     body: JSON.stringify(payload)
   });
   if(!r.ok){ alert('Error guardando'); return; }
+  alert('✅ Guardado');
 }
 
 document.getElementById('btnSaveTariffs').onclick = () => saveJSON(`${API}/settings/tariffs`, {
@@ -314,12 +358,13 @@ document.getElementById('btnSaveProvider').onclick = async () => {
 
 document.getElementById('btnUploadCatalog').onclick = async () => {
   const fd = new FormData();
-  const file = document.getElementById('providerCatalog').files[0];
+  const file = catalogInput.files[0];
   if(!file) return alert('Selecciona un archivo');
   fd.append('file', file);
   const r = await fetch(`${API}/settings/provider/catalog`, { method:'POST', body: fd });
   const j = await r.json();
-  document.getElementById('catalogStatus').value = j.status || 'procesado';
+  document.getElementById('catalogStatus').value = j.status === 'error' ? '❌ Error' : '✅ Procesado';
+  if(j.status !== 'error') alert('✅ Catálogo subido');
 };
 
 document.getElementById('btnSavePrefixes').onclick = () => saveJSON(`${API}/settings/prefixes`, {

--- a/frontend/pages/settings.html
+++ b/frontend/pages/settings.html
@@ -16,6 +16,7 @@
     .toolbar-right { display:flex; gap:.5rem; align-items:center; margin-left:auto; }
     .row { display:flex; gap: var(--s4); align-items:center; flex-wrap:wrap; }
     .w240{ width:240px; }
+    .upload-status{ font-size:.85rem; margin-top:4px; }
   </style>
 </head>
 <body>
@@ -36,29 +37,20 @@
         <div class="w240">
           <span>Subir archivo(s)</span>
           <label id="aiDrop" class="drop-zone">Arrastra o haz clic<input id="aiFiles" type="file" multiple></label>
+          <div id="aiFileStatus" class="upload-status"></div>
         </div>
 
         <button id="btnUploadAI" class="btn secondary">Subir archivo</button>
 
         <div class="inline">
           <span>Subidos</span><strong id="aiUploaded">0</strong>
-          <label class="inline">Estado:
-            <select id="aiStatus" class="input">
-              <option value="idle">Sin entrenar</option>
-              <option value="processing">⏳ Procesando…</option>
-              <option value="ok">✅ OK</option>
-              <option value="error">❌ Error</option>
-            </select>
-          </label>
+          <span>Estado:</span><span id="aiStatus" class="badge idle">Sin entrenar</span>
         </div>
-
-        <div class="toolbar-right">
-          <button id="btnTrain" class="btn primary">
-            <span class="chip">⚙️</span> Entrenar IA
-          </button>
-          <button id="btnResetAI" class="btn danger">Resetear</button>
-          <button id="btnDownloadModel" class="btn secondary">Descargar modelo</button>
-        </div>
+      </div>
+      <div class="toolbar" style="justify-content:flex-end; margin-top: var(--s3);">
+        <button id="btnTrain" class="btn primary"><span class="chip">⚙️</span> Entrenar IA</button>
+        <button id="btnResetAI" class="btn secondary danger">Resetear</button>
+        <button id="btnDownloadModel" class="btn tertiary">Descargar modelo</button>
       </div>
       <div id="trainHint" class="hint" style="margin-top:.6rem; display:none;">
         Entrenando… <span class="spinner"></span>
@@ -72,17 +64,11 @@
       <div class="grid" style="grid-template-columns: repeat(3, 1fr);">
         <label>€/hora <input id="rateHour" class="input" type="number" placeholder="45" step="1"></label>
 
-        <label>Mínimo computable
-          <select id="minBlock" class="input">
-            <!-- 5' steps up to 120' -->
-          </select>
-        </label>
+        <label>Mínimo computable</label>
+        <div id="minBlock" class="segmented" style="margin-bottom:var(--s4);"></div>
 
-        <label>Escalado de tiempo
-          <select id="stepBlock" class="input">
-            <!-- 5' steps up to 120' -->
-          </select>
-        </label>
+        <label>Escalado de tiempo</label>
+        <div id="stepBlock" class="segmented" style="margin-bottom:var(--s4);"></div>
 
         <details class="advanced" style="grid-column:1/-1; margin-top:var(--s3);">
           <summary>Opciones avanzadas</summary>
@@ -121,18 +107,18 @@
         <div class="w240">
           <span>Subir catálogo</span>
           <label id="catalogDrop" class="drop-zone">Arrastra o haz clic<input id="providerCatalog" type="file"></label>
+          <div id="catalogFileStatus" class="upload-status"></div>
         </div>
 
         <button id="btnUploadCatalog" class="btn secondary">Subir archivo</button>
 
         <div class="inline">
           <span>Estado:</span>
-          <input id="catalogStatus" class="input" value="⏳ Procesando…" style="width:160px" />
+          <span id="catalogStatus" class="badge idle">Sin subir</span>
         </div>
-
-        <div class="toolbar-right">
-          <button id="btnSaveProvider" class="btn primary">Guardar</button>
-        </div>
+      </div>
+      <div class="toolbar" style="justify-content:flex-end; margin-top: var(--s3);">
+        <button id="btnSaveProvider" class="btn primary">Guardar</button>
       </div>
     </article>
 
@@ -164,8 +150,8 @@
       <div class="grid" style="grid-template-columns: repeat(2, 1fr);">
         <label>Nombre fiscal <input id="taxName" class="input" /></label>
         <label>NIF/CIF <input id="taxId" class="input" /></label>
-        <label>Dirección <input id="taxAddress" class="input" /></label>
-        <label>Ciudad / CP <input id="taxCityZip" class="input" /></label>
+        <label>Dirección <input id="taxAddress" class="input" placeholder="C/ Mayor 123, Madrid"/></label>
+        <label>Ciudad / CP <input id="taxCityZip" class="input" placeholder="Madrid, 28080"/></label>
       </div>
       <div class="toolbar" style="justify-content:flex-end;">
         <button id="btnSaveFiscal" class="btn primary">Guardar</button>
@@ -205,13 +191,14 @@
     <!-- Modelo de email -->
     <article id="email" class="card">
       <h3>✉️ Modelo de email</h3>
-      <label>Asunto <input id="emailSubject" class="input" placeholder="Tu presupuesto {numero}"/></label>
+      <label>Asunto <input id="emailSubject" class="input" style="font-family:monospace;" placeholder="Tu presupuesto {numero}"/></label>
       <label style="margin-top:.6rem;">Cuerpo</label>
-      <textarea id="emailBody" class="input" placeholder="Hola {cliente}, adjuntamos tu presupuesto por importe {importe}. Enlace: {enlace}"></textarea>
+      <textarea id="emailBody" class="input" style="height:140px; font-family:monospace;" placeholder="Hola {cliente}, adjuntamos tu presupuesto por importe {importe}. Enlace: {enlace}"></textarea>
+      <div id="emailPreview" class="preview-box" style="margin-top:var(--s3);"></div>
       <div class="toolbar" style="justify-content:flex-end; margin-top: var(--s3);">
         <button id="btnSaveEmail" class="btn primary">Guardar</button>
       </div>
-      <p class="hint">Variables disponibles: {cliente}, {importe}, {enlace}, {numero}.</p>
+      <span class="muted" title="{cliente}, {importe}, {enlace}, {numero}" style="font-size:.85rem;">ℹ️ Variables disponibles</span>
     </article>
 
   </section>
@@ -219,8 +206,18 @@
 
 <!--#include "partials/footer.html" -->
 
+<div id="toast" class="toast"></div>
+
 <script>
 const API = location.origin.replace(/\/$/, ''); // adjust if FE+BE on different hosts
+
+// toast helper
+const toastBox = document.getElementById('toast');
+function toast(msg){
+  toastBox.textContent = msg;
+  toastBox.classList.add('show');
+  setTimeout(()=>toastBox.classList.remove('show'), 2000);
+}
 
 // Format minutes as m' or h h'
 function fmtMinutes(m){
@@ -230,24 +227,23 @@ function fmtMinutes(m){
   return min ? `${h}h ${min}'` : `${h}h`;
 }
 
-// Fill 5' steps (5..120)
-function fillSteps(sel){
-  sel.innerHTML='';
-  for(let m=5;m<=120;m+=5){
-    const o=document.createElement('option');
-    o.value=m; o.textContent=fmtMinutes(m);
-    sel.appendChild(o);
-  }
+// Build segmented controls
+function buildSegmented(id, values, def){
+  const cont=document.getElementById(id);
+  cont.innerHTML = values.map(v=>`<label><input type="radio" name="${id}" value="${v}"><span>${fmtMinutes(v)}</span></label>`).join('');
+  const defInput = cont.querySelector(`input[value="${def}"]`) || cont.querySelector('input');
+  if(defInput) defInput.checked = true;
 }
 
-const minBlock = document.getElementById('minBlock');
-const stepBlock = document.getElementById('stepBlock');
-fillSteps(minBlock); fillSteps(stepBlock);
+buildSegmented('minBlock',[5,10,15,30,60],30);
+buildSegmented('stepBlock',[5,10,15,30,60],30);
 
 // drop zones
 const aiFiles = document.getElementById('aiFiles');
 const catalogInput = document.getElementById('providerCatalog');
 const logoFile = document.getElementById('logoFile');
+const aiFileStatus = document.getElementById('aiFileStatus');
+const catalogFileStatus = document.getElementById('catalogFileStatus');
 
 function bindDropZone(zone, input){
   zone.addEventListener('click', () => input.click());
@@ -260,12 +256,15 @@ const aiDrop = document.getElementById('aiDrop');
 bindDropZone(aiDrop, aiFiles);
 aiFiles.addEventListener('change', () => {
   aiDrop.textContent = aiFiles.files.length ? `${aiFiles.files.length} archivo(s)` : 'Arrastra o haz clic';
+  aiFileStatus.textContent = aiFiles.files.length ? [...aiFiles.files].map(f=>`⏳ ${f.name}`).join(', ') : '';
 });
 
 const catalogDrop = document.getElementById('catalogDrop');
 bindDropZone(catalogDrop, catalogInput);
 catalogInput.addEventListener('change', () => {
-  catalogDrop.textContent = catalogInput.files[0]?.name || 'Arrastra o haz clic';
+  const f = catalogInput.files[0];
+  catalogDrop.textContent = f?.name || 'Arrastra o haz clic';
+  catalogFileStatus.textContent = f ? `⏳ ${f.name}` : '';
 });
 
 const logoDrop = document.getElementById('logoDrop');
@@ -298,6 +297,7 @@ const btnResetAI = document.getElementById('btnResetAI');
 const btnDownloadModel = document.getElementById('btnDownloadModel');
 const aiStatus = document.getElementById('aiStatus');
 const trainHint = document.getElementById('trainHint');
+const catalogStatus = document.getElementById('catalogStatus');
 
 btnUploadAI.onclick = async () => {
   const fd = new FormData();
@@ -305,7 +305,8 @@ btnUploadAI.onclick = async () => {
   const r = await fetch(`${API}/settings/ai/uploads`, { method:'POST', body: fd });
   const j = await r.json();
   aiUploaded.textContent = j.count ?? 0;
-  alert('✅ Archivos subidos');
+  aiFileStatus.textContent = [...aiFiles.files].map(f=>`✅ ${f.name}`).join(', ');
+  toast('Archivos subidos');
 };
 
 btnTrain.onclick = async () => {
@@ -313,11 +314,18 @@ btnTrain.onclick = async () => {
   btnTrain.disabled = true;
   const r = await fetch(`${API}/settings/ai/train`, { method:'POST' });
   const j = await r.json().catch(()=>({}));
-  aiStatus.value = j.status || 'processing';
+  aiStatus.className='badge pending';
+  aiStatus.textContent='Procesando…';
   setTimeout(async () => { // poll once for MVP
     const rr = await fetch(`${API}/settings/ai/status`);
     const jj = await rr.json();
-    aiStatus.value = jj.status || 'ok';
+    if(jj.status === 'error'){
+      aiStatus.className='badge error';
+      aiStatus.textContent='Error';
+    } else {
+      aiStatus.className='badge ok';
+      aiStatus.textContent='Completado';
+    }
     trainHint.style.display = 'none';
     btnTrain.disabled = false;
   }, 2500);
@@ -326,45 +334,56 @@ btnTrain.onclick = async () => {
 btnResetAI.onclick = async () => {
   await fetch(`${API}/settings/ai/reset`, { method:'POST' });
   aiUploaded.textContent = '0';
-  aiStatus.value = 'idle';
+  aiStatus.className='badge idle';
+  aiStatus.textContent='Sin entrenar';
 };
 
 btnDownloadModel.onclick = () => { window.location = `${API}/settings/ai/model`; };
 
 // ---- SAVE handlers
-async function saveJSON(url, payload){
+async function saveJSON(url, payload, msg){
   const r = await fetch(url, {
     method:'PUT',
     headers:{ 'Content-Type':'application/json' },
     body: JSON.stringify(payload)
   });
-  if(!r.ok){ alert('Error guardando'); return; }
-  alert('✅ Guardado');
+  if(!r.ok){ toast('Error guardando'); return; }
+  toast(msg || 'Guardado');
 }
 
 document.getElementById('btnSaveTariffs').onclick = () => saveJSON(`${API}/settings/tariffs`, {
   rate_hour: +document.getElementById('rateHour').value,
-  min_minutes: +document.getElementById('minBlock').value,
-  step_minutes: +document.getElementById('stepBlock').value,
+  min_minutes: +document.querySelector('#minBlock input:checked').value,
+  step_minutes: +document.querySelector('#stepBlock input:checked').value,
   markup_percent: +document.getElementById('markup').value,
   vat_percent: +document.getElementById('vat').value,
   travel_per_km: +document.getElementById('travelKm').value
-});
+}, 'Tarifas guardadas correctamente');
 
 document.getElementById('btnSaveProvider').onclick = async () => {
   const chosen = provider.value === 'other' ? document.getElementById('otherProvider').value : provider.value;
-  await saveJSON(`${API}/settings/provider`, { default_provider: chosen });
+  await saveJSON(`${API}/settings/provider`, { default_provider: chosen }, 'Proveedor guardado');
 };
 
 document.getElementById('btnUploadCatalog').onclick = async () => {
   const fd = new FormData();
   const file = catalogInput.files[0];
-  if(!file) return alert('Selecciona un archivo');
+  if(!file) return toast('Selecciona un archivo');
   fd.append('file', file);
+  catalogStatus.className='badge pending';
+  catalogStatus.textContent='Procesando…';
   const r = await fetch(`${API}/settings/provider/catalog`, { method:'POST', body: fd });
   const j = await r.json();
-  document.getElementById('catalogStatus').value = j.status === 'error' ? '❌ Error' : '✅ Procesado';
-  if(j.status !== 'error') alert('✅ Catálogo subido');
+  if(j.status === 'error'){
+    catalogStatus.className='badge error';
+    catalogStatus.textContent='Error';
+    catalogFileStatus.textContent = `❌ ${file.name}`;
+  } else {
+    catalogStatus.className='badge ok';
+    catalogStatus.textContent='Procesado';
+    catalogFileStatus.textContent = `✅ ${file.name}`;
+    toast('Catálogo subido');
+  }
 };
 
 document.getElementById('btnSavePrefixes').onclick = () => saveJSON(`${API}/settings/prefixes`, {
@@ -376,14 +395,14 @@ document.getElementById('btnSavePrefixes').onclick = () => saveJSON(`${API}/sett
     invoice_next: +document.getElementById('resetInvoice').value || null,
     work_next: +document.getElementById('resetWork').value || null
   }
-});
+}, 'Prefijos guardados');
 
 document.getElementById('btnSaveFiscal').onclick = () => saveJSON(`${API}/settings/fiscal`, {
   legal_name: document.getElementById('taxName').value,
   tax_id: document.getElementById('taxId').value,
   address: document.getElementById('taxAddress').value,
   city_zip: document.getElementById('taxCityZip').value
-});
+}, 'Datos fiscales guardados');
 
 document.getElementById('btnSaveBranding').onclick = async () => {
   // upload logo if selected
@@ -395,7 +414,7 @@ document.getElementById('btnSaveBranding').onclick = async () => {
   await saveJSON(`${API}/settings/branding`, {
     invoice_template: document.getElementById('tplInvoice').value,
     quote_template: document.getElementById('tplQuote').value
-  });
+  }, 'Branding guardado');
 };
 
 document.getElementById('btnPreviewBrand').onclick = () => window.open(`${API}/settings/branding/preview`, '_blank');
@@ -403,7 +422,23 @@ document.getElementById('btnPreviewBrand').onclick = () => window.open(`${API}/s
 document.getElementById('btnSaveEmail').onclick = () => saveJSON(`${API}/settings/email-template`, {
   subject: document.getElementById('emailSubject').value,
   body: document.getElementById('emailBody').value
-});
+}, 'Modelo de email guardado');
+
+const emailSubject = document.getElementById('emailSubject');
+const emailBody = document.getElementById('emailBody');
+const emailPreview = document.getElementById('emailPreview');
+function renderEmail(){
+  const subj = emailSubject.value.replace('{numero}','PRES-2025');
+  const body = emailBody.value
+    .replace('{cliente}','Juan')
+    .replace('{importe}','450€')
+    .replace('{enlace}','fixhub.com/presupuesto/2025')
+    .replace('{numero}','PRES-2025');
+  emailPreview.innerHTML = `<strong>${subj}</strong><p>${body}</p>`;
+}
+emailSubject.addEventListener('input', renderEmail);
+emailBody.addEventListener('input', renderEmail);
+renderEmail();
 
 // ---- Load initial values
 (async function boot(){
@@ -414,8 +449,10 @@ document.getElementById('btnSaveEmail').onclick = () => saveJSON(`${API}/setting
 
     // Map settings to fields (all optional)
     document.getElementById('rateHour').value = s.tariffs?.rate_hour ?? '';
-    document.getElementById('minBlock').value = s.tariffs?.min_minutes ?? '30';
-    document.getElementById('stepBlock').value = s.tariffs?.step_minutes ?? '30';
+    const mb = document.querySelector(`#minBlock input[value="${s.tariffs?.min_minutes ?? 30}"]`);
+    if(mb) mb.checked = true;
+    const sb = document.querySelector(`#stepBlock input[value="${s.tariffs?.step_minutes ?? 30}"]`);
+    if(sb) sb.checked = true;
     document.getElementById('markup').value = s.tariffs?.markup_percent ?? '';
     document.getElementById('vat').value = s.tariffs?.vat_percent ?? '';
     document.getElementById('travelKm').value = s.tariffs?.travel_per_km ?? '';
@@ -445,6 +482,7 @@ document.getElementById('btnSaveEmail').onclick = () => saveJSON(`${API}/setting
 
     document.getElementById('emailSubject').value = s.email_template?.subject ?? '';
     document.getElementById('emailBody').value = s.email_template?.body ?? '';
+    renderEmail();
   }catch(e){ /* noop */ }
 })();
 </script>

--- a/frontend/public/css/style.css
+++ b/frontend/public/css/style.css
@@ -340,6 +340,32 @@ footer a:hover{ text-decoration:underline; }
 .toolbar { display:flex; gap:var(--s3); flex-wrap:wrap; align-items:center; }
 .toolbar .input, .toolbar select { padding:8px 10px; border:1px solid var(--border); border-radius:8px; background:#fff; }
 
+/* unified form controls */
+.input{ padding:8px 10px; border:1px solid var(--border); border-radius:8px; background:#fff; }
+select.input{ appearance:none; background:#fff url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%236b7280'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M19 9l-7 7-7-7'/%3E%3C/svg%3E") no-repeat right 10px center/16px; padding-right:32px; }
+
+/* segmented controls */
+.segmented{ display:flex; border:1px solid var(--border); border-radius:8px; overflow:hidden; }
+.segmented label{ flex:1; text-align:center; cursor:pointer; }
+.segmented input{ display:none; }
+.segmented span{ display:block; padding:8px 10px; }
+.segmented input:checked + span{ background:var(--sky); color:#fff; }
+
+/* badges for statuses */
+.badge{ display:inline-flex; align-items:center; gap:4px; padding:4px 8px; border-radius:8px; font-size:.85rem; }
+.badge.idle{ background:var(--border); color:var(--steel); }
+.badge.ok{ background:var(--mint); color:#fff; }
+.badge.error{ background:var(--rose); color:#fff; }
+.badge.pending{ background:var(--amber); color:#fff; }
+
+/* tertiary button */
+.btn.tertiary{ background:#e5e7eb; color:var(--ink-2); border:1px solid var(--border); box-shadow:none; }
+.btn.secondary.danger{ color:var(--rose); border-color:var(--rose); }
+
+/* toast notifications */
+.toast{ position:fixed; bottom:20px; right:20px; background:var(--ink-2); color:#fff; padding:10px 14px; border-radius:8px; box-shadow:var(--shadow); opacity:0; pointer-events:none; transition:opacity .3s ease; }
+.toast.show{ opacity:1; }
+
 .upgrade { background:rgba(37,99,235,.06); border:1px dashed rgba(37,99,235,.4); padding:var(--s4); border-radius: var(--radius); }
 
 body.index .hero .btn.primary {

--- a/frontend/public/css/style.css
+++ b/frontend/public/css/style.css
@@ -162,17 +162,30 @@ nav a:focus-visible{ outline: 2px solid #fff; outline-offset: 4px; border-radius
 .btn:focus-visible{ outline: 3px solid #fff; outline-offset: 2px; }
 
 .btn.primary{
-  background-image: linear-gradient(180deg, var(--sky) 0%, var(--sky-600) 100%);
-}
-.btn.secondary{
   background-image: linear-gradient(180deg, #22c55e 0%, #16a34a 100%);
 }
-.btn.tertiary{
-  background-image: linear-gradient(180deg, #ff000d 0%, #ff6a00 100%);
+.btn.secondary{
+  background: var(--paper-2);
+  color: var(--ink-2);
+  border:1px solid var(--border);
+  box-shadow:none;
 }
 .btn.danger{
   background-image: linear-gradient(180deg, #ef4444 0%, #dc2626 100%);
 }
+
+/* drag & drop zones */
+.drop-zone{
+  border:2px dashed var(--border);
+  border-radius:var(--radius-sm);
+  padding:var(--s5);
+  text-align:center;
+  color:var(--muted);
+  cursor:pointer;
+  background:var(--paper-2);
+}
+.drop-zone.hover{ border-color:var(--sky); background:var(--paper); }
+.drop-zone input{ display:none; }
 
 .cta-buttons{
   display:flex; flex-wrap:wrap; justify-content:center; gap: var(--s3);


### PR DESCRIPTION
## Summary
- Use green primary buttons and neutral secondary buttons
- Add drag-and-drop upload zones with instant feedback
- Collapse advanced tariff and prefix options behind toggles

## Testing
- `pytest` *(fails: RuntimeError: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9491185688325bcec4f8713c4a653