### PR TITLE
style: unify selects and add badges

### DIFF
--- a/frontend/pages/about.html
+++ b/frontend/pages/about.html
@@ -137,7 +137,7 @@
           </div>
 
           <label>Motivo
-            <select id="reason" class="input" required>
+            <select id="reason" class="input form-select" required>
               <option value="">Selecciona…</option>
               <option>Quiero una demo</option>
               <option>Dudas de facturación</option>

--- a/frontend/pages/admin.html
+++ b/frontend/pages/admin.html
@@ -36,8 +36,8 @@
   <section class="card">
     <h3>Exportaciones</h3>
     <div class="toolbar">
-      <select class="input"><option>CSV</option><option>XML</option></select>
-      <select class="input"><option>Trabajos</option><option>Facturas</option><option>Clientes</option></select>
+      <select class="input form-select"><option>CSV</option><option>XML</option></select>
+      <select class="input form-select"><option>Trabajos</option><option>Facturas</option><option>Clientes</option></select>
       <button class="btn secondary">Exportar</button>
     </div>
   </section>

--- a/frontend/pages/pricing.html
+++ b/frontend/pages/pricing.html
@@ -157,7 +157,7 @@
       <h3>Team</h3>
       <div class="select-row">
         <label for="teamSize"><strong>Personas:</strong></label>
-        <select id="teamSize">
+        <select id="teamSize" class="form-select">
           <option value="1">1</option>
           <option value="2">2</option>
           <option value="3" selected>3</option>

--- a/frontend/pages/register.html
+++ b/frontend/pages/register.html
@@ -15,7 +15,7 @@
     .hidden{ display:none !important; }
 
     /* Ajusta SELECT al mismo estilo que input/textarea del theme */
-    select{
+    .form-select{
       width:100%; font: inherit; color:var(--ink-2);
       padding: 12px 14px; border-radius: 12px;
       border:1px solid var(--border); background:#fff;
@@ -33,7 +33,7 @@
       background-size: 6px 6px, 6px 6px, 1px 60%;
       background-repeat: no-repeat;
     }
-    select:focus{
+    .form-select:focus{
       outline:none; border-color: rgba(37,99,235,.6);
       box-shadow: 0 0 0 4px rgba(37,99,235,.12);
     }
@@ -71,7 +71,7 @@
       <label class="input-inline"><input type="radio" name="plan" value="Team"> Team</label>
       <div id="teamSeatsWrap" class="input-inline hidden">
         <span>Personas:</span>
-        <select id="teamSeats" name="team_seats">
+        <select id="teamSeats" name="team_seats" class="form-select">
           <option value="2">2</option>
           <option value="3" selected>3</option>
           <option value="4">4</option>
@@ -138,7 +138,7 @@
       </div>
       <div>
         <label for="sector">Sector / Industria *</label>
-        <select id="sector" name="sector" required>
+        <select id="sector" name="sector" required class="form-select">
           <option value="" disabled selected>Selecciona sector</option>
           <option>Electricidad</option>
           <option>Fontanería</option>
@@ -159,7 +159,7 @@
     <div class="form-row-3">
       <div>
         <label for="country">País *</label>
-        <select id="country" name="country" required>
+        <select id="country" name="country" required class="form-select">
           <option value="ES" selected>España</option>
           <option value="PT">Portugal</option>
           <option value="FR">Francia</option>
@@ -168,7 +168,7 @@
       </div>
       <div>
         <label for="region">Provincia *</label>
-        <select id="region" name="region" required>
+        <select id="region" name="region" required class="form-select">
           <option value="" disabled selected></option>
             <option>A Coruña</option><option>Albacete</option><option>Alicante</option><option>Almería</option><option>Álava</option>
             <option>Asturias</option><option>Ávila</option><option>Badajoz</option><option>Barcelona</option><option>Bizkaia</option>

--- a/frontend/pages/reports.html
+++ b/frontend/pages/reports.html
@@ -15,7 +15,7 @@
   <section class="card">
     <div class="toolbar">
       <input class="input" placeholder="Buscar por cliente, trabajo o ID">
-      <select class="input">
+      <select class="input form-select">
         <option>Todos los estados</option>
         <option>Abierto</option>
         <option>En curso</option>

--- a/frontend/pages/settings.html
+++ b/frontend/pages/settings.html
@@ -41,14 +41,8 @@
 
         <div class="inline">
           <span>Subidos</span><strong id="aiUploaded">0</strong>
-          <label class="inline">Estado:
-            <select id="aiStatus" class="input">
-              <option value="idle">Idle</option>
-              <option value="processing">Procesando</option>
-              <option value="ok">OK</option>
-              <option value="error">Error</option>
-            </select>
-          </label>
+          <span>Estado:</span>
+          <span id="aiStatus" class="badge badge-success">{{ ia_status }}</span>
         </div>
 
         <div class="toolbar-right">
@@ -56,7 +50,7 @@
             <span class="chip">⚙️</span> Entrenar IA
           </button>
           <button id="btnResetAI" class="btn">Resetear</button>
-          <button id="btnDownloadModel" class="btn">Descargar modelo</button>
+          <button id="btnDownloadModel" class="btn btn-tertiary">Descargar modelo</button>
         </div>
       </div>
       <div id="trainHint" class="hint" style="margin-top:.6rem; display:none;">
@@ -72,13 +66,13 @@
         <label>€/hora <input id="rateHour" class="input" type="number" placeholder="45" step="1"></label>
 
         <label>Mínimo computable
-          <select id="minBlock" class="input">
+          <select id="minBlock" class="input form-select">
             <!-- 5' steps up to 120' -->
           </select>
         </label>
 
         <label>Escalado de tiempo
-          <select id="stepBlock" class="input">
+          <select id="stepBlock" class="input form-select">
             <!-- 5' steps up to 120' -->
           </select>
         </label>
@@ -99,7 +93,7 @@
       <div class="row">
         <label class="w240">
           <span>Proveedor por defecto</span>
-          <select id="provider" class="input">
+          <select id="provider" class="input form-select">
             <option value="Bricomart">Bricomart</option>
             <option value="Leroy Merlin">Leroy Merlin</option>
             <option value="Amazon Business">Amazon Business</option>
@@ -121,7 +115,7 @@
 
         <div class="inline">
           <span>Estado:</span>
-          <input id="catalogStatus" class="input" value="procesando..." style="width:160px" />
+          <span id="catalogStatus" class="badge badge-warning">{{ proveedor_status }}</span>
         </div>
 
         <div class="toolbar-right">
@@ -177,12 +171,12 @@
         </div>
         <div>
           <label>Modelo de factura</label>
-          <select id="tplInvoice" class="input">
+          <select id="tplInvoice" class="input form-select">
             <option value="A">Modelo A</option>
             <option value="B">Modelo B</option>
           </select>
           <label style="margin-top:.6rem;">Modelo de presupuesto</label>
-          <select id="tplQuote" class="input">
+          <select id="tplQuote" class="input form-select">
             <option value="A">Modelo A</option>
             <option value="B">Modelo B</option>
           </select>
@@ -270,11 +264,11 @@ btnTrain.onclick = async () => {
   btnTrain.disabled = true;
   const r = await fetch(`${API}/settings/ai/train`, { method:'POST' });
   const j = await r.json().catch(()=>({}));
-  aiStatus.value = j.status || 'processing';
+  aiStatus.textContent = j.status || 'processing';
   setTimeout(async () => { // poll once for MVP
     const rr = await fetch(`${API}/settings/ai/status`);
     const jj = await rr.json();
-    aiStatus.value = jj.status || 'ok';
+    aiStatus.textContent = jj.status || 'ok';
     trainHint.style.display = 'none';
     btnTrain.disabled = false;
   }, 2500);
@@ -283,7 +277,7 @@ btnTrain.onclick = async () => {
 btnResetAI.onclick = async () => {
   await fetch(`${API}/settings/ai/reset`, { method:'POST' });
   aiUploaded.textContent = '0';
-  aiStatus.value = 'idle';
+  aiStatus.textContent = 'idle';
 };
 
 btnDownloadModel.onclick = () => { window.location = `${API}/settings/ai/model`; };
@@ -319,7 +313,7 @@ document.getElementById('btnUploadCatalog').onclick = async () => {
   fd.append('file', file);
   const r = await fetch(`${API}/settings/provider/catalog`, { method:'POST', body: fd });
   const j = await r.json();
-  document.getElementById('catalogStatus').value = j.status || 'procesado';
+  document.getElementById('catalogStatus').textContent = j.status || 'procesado';
 };
 
 document.getElementById('btnSavePrefixes').onclick = () => saveJSON(`${API}/settings/prefixes`, {

--- a/frontend/pages/team.html
+++ b/frontend/pages/team.html
@@ -105,7 +105,7 @@
           <input id="fEmail" class="input" type="email" placeholder="persona@empresa.com" />
         </label>
         <label>Rol
-          <select id="fRole" class="input">
+          <select id="fRole" class="input form-select">
             <option value="worker">Técnico</option>
             <option value="manager">Manager</option>
             <option value="admin">Admin</option>
@@ -131,7 +131,7 @@
 
       <div class="grid">
         <label>Plan
-          <select id="mPlan" class="input">
+          <select id="mPlan" class="input form-select">
             <option value="Solo">Solo</option>
             <option value="Team">Team</option>
           </select>
@@ -139,7 +139,7 @@
 
         <div id="teamSelector" class="inline">
           <label for="mTeamSize" style="font-weight:700;">Personas</label>
-          <select id="mTeamSize" class="input" style="min-width:120px;">
+          <select id="mTeamSize" class="input form-select" style="min-width:120px;">
             <option value="1">1</option><option value="2">2</option><option value="3">3</option>
             <option value="4">4</option><option value="5">5</option><option value="6">6</option>
             <option value="7">7</option><option value="8">8+</option>

--- a/frontend/public/css/style.css
+++ b/frontend/public/css/style.css
@@ -173,6 +173,13 @@ nav a:focus-visible{ outline: 2px solid #fff; outline-offset: 4px; border-radius
 .btn.danger{
   background-image: linear-gradient(180deg, #ef4444 0%, #dc2626 100%);
 }
+.btn-tertiary{
+  background:#f3f4f6;
+  color:#374151;
+}
+.btn-tertiary:hover{
+  background:#e5e7eb;
+}
 
 .cta-buttons{
   display:flex; flex-wrap:wrap; justify-content:center; gap: var(--s3);
@@ -248,7 +255,34 @@ input:focus, textarea:focus{
   outline: none; border-color: rgba(37,99,235,.6);
   box-shadow: 0 0 0 4px rgba(37,99,235,.12);
 }
+.form-select{
+  width:100%; font: inherit; color:var(--ink-2);
+  padding: 12px 14px; border-radius: 12px;
+  border:1px solid var(--border);
+  background:#fff;
+  box-shadow: inset 0 1px 0 rgba(2,6,23,.04);
+  transition: border-color .15s ease, box-shadow .15s ease;
+  appearance:none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--muted) 50%),
+    linear-gradient(135deg, var(--muted) 50%, transparent 50%),
+    linear-gradient(to right, transparent, transparent);
+  background-position:
+    calc(100% - 20px) calc(50% - 3px),
+    calc(100% - 14px) calc(50% - 3px),
+    calc(100% - 2.2rem) 0.6rem;
+  background-size: 6px 6px, 6px 6px, 1px 60%;
+  background-repeat: no-repeat;
+}
+.form-select:focus{
+  outline:none; border-color: rgba(37,99,235,.6);
+  box-shadow: 0 0 0 4px rgba(37,99,235,.12);
+}
 textarea{ min-height: 140px; resize: vertical; }
+.badge{ padding:0.25rem 0.5rem; border-radius:0.5rem; font-weight:500; }
+.badge-success{ background:#d1fae5; color:#065f46; }
+.badge-warning{ background:#fef3c7; color:#92400e; }
+.badge-error{ background:#fee2e2; color:#991b1b; }
 button[type="submit"]{
   margin-top: var(--s4);
   background-image: linear-gradient(180deg, var(--sky) 0%, var(--sky-600) 100%);


### PR DESCRIPTION
## Summary
- style selects with shared form-select class
- replace status inputs with badges
- add tertiary button variant for model download

## Testing
- `pip install httpx` *(fails: Could not find a version)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68b95a157be483259a955495d025eefd