### PR TITLE
Improve settings UI with breadcrumbs and feedback

### DIFF
--- a/frontend/pages/settings.html
+++ b/frontend/pages/settings.html
@@ -22,6 +22,9 @@
 <!--#include "partials/header.html" -->
 
 <main class="layout">
+  <nav class="breadcrumb"><a href="./index.html">Inicio</a> &gt; Configuración</nav>
+  <h1 class="page-title">Configuración</h1>
+  <p class="page-desc">Ajusta parámetros de IA, tarifas, proveedores y branding para automatizar tus presupuestos.</p>
   <section class="grid">
 
     <!-- IA y presets -->
@@ -41,22 +44,16 @@
 
         <div class="inline">
           <span>Subidos</span><strong id="aiUploaded">0</strong>
-          <label class="inline">Estado:
-            <select id="aiStatus" class="input">
-              <option value="idle">Idle</option>
-              <option value="processing">Procesando</option>
-              <option value="ok">OK</option>
-              <option value="error">Error</option>
-            </select>
-          </label>
+          <span>Estado</span><span id="aiStatus" class="badge badge-idle">ℹ️ Sin datos</span>
         </div>
+        <div id="aiFileStatus" class="file-list" style="width:100%;"></div>
 
         <div class="toolbar-right">
-          <button id="btnTrain" class="btn secondary">
+          <button id="btnTrain" class="btn primary">
             <span class="chip">⚙️</span> Entrenar IA
           </button>
-          <button id="btnResetAI" class="btn">Resetear</button>
-          <button id="btnDownloadModel" class="btn">Descargar modelo</button>
+          <button id="btnResetAI" class="btn secondary">Resetear</button>
+          <button id="btnDownloadModel" class="btn secondary">Descargar modelo</button>
         </div>
       </div>
       <div id="trainHint" class="hint" style="margin-top:.6rem; display:none;">
@@ -89,7 +86,7 @@
       </div>
 
       <div class="toolbar" style="justify-content:flex-end; margin-top: var(--s3);">
-        <button id="btnSaveTariffs" class="btn">Guardar</button>
+        <button id="btnSaveTariffs" class="btn primary">Guardar</button>
       </div>
     </article>
 
@@ -117,15 +114,15 @@
           <input id="providerCatalog" type="file" />
         </label>
 
-        <button id="btnUploadCatalog" class="btn">Subir archivo</button>
+        <button id="btnUploadCatalog" class="btn secondary">Subir archivo</button>
 
         <div class="inline">
           <span>Estado:</span>
-          <input id="catalogStatus" class="input" value="procesando..." style="width:160px" />
+          <span id="catalogStatus" class="badge badge-idle">ℹ️ Sin datos</span>
         </div>
 
         <div class="toolbar-right">
-          <button id="btnSaveProvider" class="btn">Guardar</button>
+          <button id="btnSaveProvider" class="btn primary">Guardar</button>
         </div>
       </div>
     </article>
@@ -147,7 +144,7 @@
       </div>
       <p class="hint">El siguiente número se recalculará automáticamente al guardar.</p>
       <div class="toolbar" style="justify-content:flex-end;">
-        <button id="btnSavePrefixes" class="btn">Guardar</button>
+        <button id="btnSavePrefixes" class="btn primary">Guardar</button>
       </div>
     </article>
 
@@ -157,11 +154,11 @@
       <div class="grid" style="grid-template-columns: repeat(2, 1fr);">
         <label>Nombre fiscal <input id="taxName" class="input" /></label>
         <label>NIF/CIF <input id="taxId" class="input" /></label>
-        <label>Dirección <input id="taxAddress" class="input" /></label>
-        <label>Ciudad / CP <input id="taxCityZip" class="input" /></label>
+        <label>Dirección <input id="taxAddress" class="input" placeholder="C/ Mayor 123, Madrid" /></label>
+        <label>Ciudad / CP <input id="taxCityZip" class="input" placeholder="Madrid, 28080" /></label>
       </div>
       <div class="toolbar" style="justify-content:flex-end;">
-        <button id="btnSaveFiscal" class="btn">Guardar</button>
+        <button id="btnSaveFiscal" class="btn primary">Guardar</button>
       </div>
     </article>
 
@@ -182,13 +179,15 @@
             <option value="B">Modelo B</option>
           </select>
           <label style="margin-top:.6rem;">Modelo de presupuesto</label>
-          <select id="tplQuote" class="input">
-            <option value="A">Modelo A</option>
-            <option value="B">Modelo B</option>
-          </select>
+          <div class="inline">
+            <select id="tplQuote" class="input">
+              <option value="A">Modelo A</option>
+              <option value="B">Modelo B</option>
+            </select>
+            <button id="btnPreviewBrand" class="btn secondary">Preview</button>
+          </div>
           <div class="toolbar" style="justify-content:flex-end; margin-top: var(--s3);">
-            <button id="btnSaveBranding" class="btn">Guardar</button>
-            <button id="btnPreviewBrand" class="btn secondary">preview</button>
+            <button id="btnSaveBranding" class="btn primary">Guardar</button>
           </div>
         </div>
       </div>
@@ -198,12 +197,12 @@
     <article id="email" class="card">
       <h3>Modelo de email</h3>
       <label>Asunto <input id="emailSubject" class="input" placeholder="Tu presupuesto {numero}"/></label>
-      <label style="margin-top:.6rem;">Cuerpo</label>
+      <label style="margin-top:.6rem;">Cuerpo <span class="help-icon" title="Variables disponibles: {cliente}, {importe}, {enlace}, {numero}">?</span></label>
       <textarea id="emailBody" class="input" placeholder="Hola {cliente}, adjuntamos tu presupuesto por importe {importe}. Enlace: {enlace}"></textarea>
+      <div id="emailPreview" class="preview-box" style="margin-top:.6rem; text-align:left;"></div>
       <div class="toolbar" style="justify-content:flex-end; margin-top: var(--s3);">
-        <button id="btnSaveEmail" class="btn">Guardar</button>
+        <button id="btnSaveEmail" class="btn primary">Guardar</button>
       </div>
-      <p class="hint">Variables disponibles: {cliente}, {importe}, {enlace}, {numero}.</p>
     </article>
 
   </section>
@@ -214,12 +213,40 @@
 <script>
 const API = location.origin.replace(/\/$/, ''); // adjust if FE+BE on different hosts
 
-// Fill 5' steps (5..120)
+function setBadge(el, status){
+  el.className = 'badge';
+  switch(status){
+    case 'processing':
+      el.classList.add('badge-processing'); el.textContent = '⏳ Procesando'; break;
+    case 'ok':
+      el.classList.add('badge-ok'); el.textContent = '✅ Completado'; break;
+    case 'error':
+      el.classList.add('badge-error'); el.textContent = '❌ Error'; break;
+    default:
+      el.classList.add('badge-idle'); el.textContent = 'ℹ️ Sin datos';
+  }
+}
+
+function showToast(msg){
+  const t=document.createElement('div');
+  t.className='toast';
+  t.textContent=msg;
+  document.body.appendChild(t);
+  requestAnimationFrame(()=>t.classList.add('show'));
+  setTimeout(()=>{t.classList.remove('show'); t.remove();},3000);
+}
+
+// Fill 5' steps up to 60 then 1h format
 function fillSteps(sel){
   sel.innerHTML='';
-  for(let m=5;m<=120;m+=5){
+  for(let m=5;m<=180;m+=5){
     const o=document.createElement('option');
-    o.value=m; o.textContent=`${m}'`;
+    o.value=m;
+    if(m<60){ o.textContent=`${m}'`; }
+    else {
+      const h=Math.floor(m/60); const mm=m%60;
+      o.textContent= mm? `${h}h${mm}'` : `${h}h`;
+    }
     sel.appendChild(o);
   }
 }
@@ -234,6 +261,7 @@ const otherWrap = document.getElementById('otherProviderWrap');
 provider.addEventListener('change', () => {
   otherWrap.style.display = provider.value === 'other' ? '' : 'none';
 });
+const catalogStatus = document.getElementById('catalogStatus');
 
 // Branding preview
 const logoFile = document.getElementById('logoFile');
@@ -247,6 +275,28 @@ logoFile.addEventListener('change', () => {
   reader.readAsDataURL(f);
 });
 
+// Email preview
+const emailSubject = document.getElementById('emailSubject');
+const emailBody = document.getElementById('emailBody');
+const emailPreview = document.getElementById('emailPreview');
+function updateEmailPreview(){
+  const dummy = { cliente:'Juan', importe:'450€', enlace:'fixhub.com/presupuesto/2025', numero:'PRES-2025' };
+  const subj = (emailSubject.value || emailSubject.placeholder)
+    .replace('{cliente}', dummy.cliente)
+    .replace('{importe}', dummy.importe)
+    .replace('{enlace}', dummy.enlace)
+    .replace('{numero}', dummy.numero);
+  const body = (emailBody.value || emailBody.placeholder)
+    .replace('{cliente}', dummy.cliente)
+    .replace('{importe}', dummy.importe)
+    .replace('{enlace}', dummy.enlace)
+    .replace('{numero}', dummy.numero);
+  emailPreview.innerHTML = `<strong>Asunto:</strong> ${subj}<br><strong>Cuerpo:</strong> ${body}`;
+}
+emailSubject.addEventListener('input', updateEmailPreview);
+emailBody.addEventListener('input', updateEmailPreview);
+updateEmailPreview();
+
 // ---- IA actions
 const aiFiles = document.getElementById('aiFiles');
 const aiUploaded = document.getElementById('aiUploaded');
@@ -256,25 +306,36 @@ const btnResetAI = document.getElementById('btnResetAI');
 const btnDownloadModel = document.getElementById('btnDownloadModel');
 const aiStatus = document.getElementById('aiStatus');
 const trainHint = document.getElementById('trainHint');
+const aiFileStatus = document.getElementById('aiFileStatus');
 
 btnUploadAI.onclick = async () => {
+  if(aiFiles.files.length===0){
+    aiFileStatus.textContent = '❌ No se han proporcionado archivos';
+    setBadge(aiStatus,'idle');
+    return;
+  }
+  aiFileStatus.innerHTML = Array.from(aiFiles.files).map(f=>`${f.name} ⏳`).join('<br>');
+  setBadge(aiStatus,'processing');
   const fd = new FormData();
   [...aiFiles.files].forEach(f => fd.append('files', f));
   const r = await fetch(`${API}/settings/ai/uploads`, { method:'POST', body: fd });
   const j = await r.json();
   aiUploaded.textContent = j.count ?? 0;
+  aiFileStatus.innerHTML = Array.from(aiFiles.files).map(f=>`${f.name} ✅`).join('<br>');
+  setBadge(aiStatus, j.status || 'ok');
 };
 
 btnTrain.onclick = async () => {
   trainHint.style.display = '';
   btnTrain.disabled = true;
+  setBadge(aiStatus,'processing');
   const r = await fetch(`${API}/settings/ai/train`, { method:'POST' });
   const j = await r.json().catch(()=>({}));
-  aiStatus.value = j.status || 'processing';
+  setBadge(aiStatus, j.status || 'processing');
   setTimeout(async () => { // poll once for MVP
     const rr = await fetch(`${API}/settings/ai/status`);
     const jj = await rr.json();
-    aiStatus.value = jj.status || 'ok';
+    setBadge(aiStatus, jj.status || 'ok');
     trainHint.style.display = 'none';
     btnTrain.disabled = false;
   }, 2500);
@@ -283,19 +344,21 @@ btnTrain.onclick = async () => {
 btnResetAI.onclick = async () => {
   await fetch(`${API}/settings/ai/reset`, { method:'POST' });
   aiUploaded.textContent = '0';
-  aiStatus.value = 'idle';
+  aiFileStatus.textContent = '';
+  setBadge(aiStatus,'idle');
 };
 
 btnDownloadModel.onclick = () => { window.location = `${API}/settings/ai/model`; };
 
 // ---- SAVE handlers
-async function saveJSON(url, payload){
+async function saveJSON(url, payload, okMsg){
   const r = await fetch(url, {
     method:'PUT',
     headers:{ 'Content-Type':'application/json' },
     body: JSON.stringify(payload)
   });
   if(!r.ok){ alert('Error guardando'); return; }
+  showToast(okMsg || 'Guardado correctamente');
 }
 
 document.getElementById('btnSaveTariffs').onclick = () => saveJSON(`${API}/settings/tariffs`, {
@@ -305,21 +368,28 @@ document.getElementById('btnSaveTariffs').onclick = () => saveJSON(`${API}/setti
   markup_percent: +document.getElementById('markup').value,
   vat_percent: +document.getElementById('vat').value,
   travel_per_km: +document.getElementById('travelKm').value
-});
+}, 'Tarifas guardadas correctamente');
 
 document.getElementById('btnSaveProvider').onclick = async () => {
   const chosen = provider.value === 'other' ? document.getElementById('otherProvider').value : provider.value;
-  await saveJSON(`${API}/settings/provider`, { default_provider: chosen });
+  await saveJSON(`${API}/settings/provider`, { default_provider: chosen }, 'Proveedor guardado');
 };
 
 document.getElementById('btnUploadCatalog').onclick = async () => {
-  const fd = new FormData();
   const file = document.getElementById('providerCatalog').files[0];
-  if(!file) return alert('Selecciona un archivo');
+  if(!file){
+    catalogStatus.className='badge badge-error';
+    catalogStatus.textContent='❌ No se han proporcionado archivos';
+    return;
+  }
+  catalogStatus.className='badge badge-processing';
+  catalogStatus.textContent=`⏳ ${file.name}`;
+  const fd = new FormData();
   fd.append('file', file);
   const r = await fetch(`${API}/settings/provider/catalog`, { method:'POST', body: fd });
   const j = await r.json();
-  document.getElementById('catalogStatus').value = j.status || 'procesado';
+  catalogStatus.className = j.status === 'error' ? 'badge badge-error' : 'badge badge-ok';
+  catalogStatus.textContent = `${j.status === 'error' ? '❌' : '✅'} ${file.name}`;
 };
 
 document.getElementById('btnSavePrefixes').onclick = () => saveJSON(`${API}/settings/prefixes`, {
@@ -331,14 +401,14 @@ document.getElementById('btnSavePrefixes').onclick = () => saveJSON(`${API}/sett
     invoice_next: +document.getElementById('resetInvoice').value || null,
     work_next: +document.getElementById('resetWork').value || null
   }
-});
+}, 'Prefijos guardados');
 
 document.getElementById('btnSaveFiscal').onclick = () => saveJSON(`${API}/settings/fiscal`, {
   legal_name: document.getElementById('taxName').value,
   tax_id: document.getElementById('taxId').value,
   address: document.getElementById('taxAddress').value,
   city_zip: document.getElementById('taxCityZip').value
-});
+}, 'Datos fiscales guardados');
 
 document.getElementById('btnSaveBranding').onclick = async () => {
   // upload logo if selected
@@ -350,7 +420,7 @@ document.getElementById('btnSaveBranding').onclick = async () => {
   await saveJSON(`${API}/settings/branding`, {
     invoice_template: document.getElementById('tplInvoice').value,
     quote_template: document.getElementById('tplQuote').value
-  });
+  }, 'Branding guardado');
 };
 
 document.getElementById('btnPreviewBrand').onclick = () => window.open(`${API}/settings/branding/preview`, '_blank');
@@ -358,7 +428,7 @@ document.getElementById('btnPreviewBrand').onclick = () => window.open(`${API}/s
 document.getElementById('btnSaveEmail').onclick = () => saveJSON(`${API}/settings/email-template`, {
   subject: document.getElementById('emailSubject').value,
   body: document.getElementById('emailBody').value
-});
+}, 'Email guardado');
 
 // ---- Load initial values
 (async function boot(){
@@ -400,6 +470,7 @@ document.getElementById('btnSaveEmail').onclick = () => saveJSON(`${API}/setting
 
     document.getElementById('emailSubject').value = s.email_template?.subject ?? '';
     document.getElementById('emailBody').value = s.email_template?.body ?? '';
+    updateEmailPreview();
   }catch(e){ /* noop */ }
 })();
 </script>

--- a/frontend/pages/settings.html
+++ b/frontend/pages/settings.html
@@ -30,31 +30,30 @@
     <!-- IA y presets -->
     <article id="ia" class="card">
       <div class="section-head">
+        <span class="chip">🤖</span>
         <h3 style="margin:0;">IA y presets</h3>
         <span class="hint-right">Sube mínimo 3 presupuestos previos</span>
       </div>
 
       <div class="row">
-        <label class="w240">
-          <span>Subir archivo(s)</span>
+        <label class="drop-zone w240">
           <input id="aiFiles" type="file" multiple />
+          <span>Arrastra o haz clic para subir</span>
         </label>
 
         <button id="btnUploadAI" class="btn secondary">Subir archivo</button>
 
         <div class="inline">
           <span>Subidos</span><strong id="aiUploaded">0</strong>
-          <span>Estado</span><span id="aiStatus" class="badge badge-idle">ℹ️ Sin datos</span>
+          <span>Estado</span><span id="aiStatus" class="badge badge-idle" aria-live="polite">ℹ️ Sin datos</span>
         </div>
         <div id="aiFileStatus" class="file-list" style="width:100%;"></div>
+      </div>
 
-        <div class="toolbar-right">
-          <button id="btnTrain" class="btn primary">
-            <span class="chip">⚙️</span> Entrenar IA
-          </button>
-          <button id="btnResetAI" class="btn secondary">Resetear</button>
-          <button id="btnDownloadModel" class="btn secondary">Descargar modelo</button>
-        </div>
+      <div class="toolbar" style="justify-content:flex-end; margin-top: var(--s3);">
+        <button id="btnTrain" class="btn primary"><span class="chip">⚙️</span> Entrenar IA</button>
+        <button id="btnResetAI" class="btn secondary">Resetear</button>
+        <button id="btnDownloadModel" class="btn secondary">Descargar modelo</button>
       </div>
       <div id="trainHint" class="hint" style="margin-top:.6rem; display:none;">
         Entrenando… <span class="spinner"></span>
@@ -63,25 +62,21 @@
 
     <!-- Tarifas y márgenes -->
     <article id="tarifas" class="card">
-      <h3 style="margin-top:0;">Tarifas y márgenes</h3>
+      <div class="section-head">
+        <span class="chip">⚙️</span>
+        <h3 style="margin:0;">Tarifas y márgenes</h3>
+      </div>
 
-      <div class="grid" style="grid-template-columns: repeat(3, 1fr);">
-        <label>€/hora <input id="rateHour" class="input" type="number" placeholder="45" step="1"></label>
-
+      <div class="grid" style="grid-template-columns: repeat(2, 1fr);">
+        <label>Tarifa por hora (€) <input id="rateHour" class="input" type="number" placeholder="45" step="1"></label>
         <label>Mínimo computable
-          <select id="minBlock" class="input">
-            <!-- 5' steps up to 120' -->
-          </select>
+          <select id="minBlock" class="input"></select>
         </label>
-
-        <label>Escalado de tiempo
-          <select id="stepBlock" class="input">
-            <!-- 5' steps up to 120' -->
-          </select>
+        <label>Escalado de tiempo <span class="help-icon" title="Intervalo mínimo de facturación">?</span>
+          <select id="stepBlock" class="input"></select>
         </label>
-
-        <label>Markup materiales (%) <input id="markup" class="input" type="number" placeholder="20" step="1"></label>
         <label>IVA (%) <input id="vat" class="input" type="number" placeholder="21" step="1"></label>
+        <label>Markup materiales (%) <span class="help-icon" title="Recargo sobre materiales">?</span><input id="markup" class="input" type="number" placeholder="20" step="1"></label>
         <label>Coste desplazamiento (€/km) <input id="travelKm" class="input" type="number" placeholder="0.5" step="0.1"></label>
       </div>
 
@@ -92,7 +87,10 @@
 
     <!-- Proveedores -->
     <article id="proveedor" class="card">
-      <h3>Proveedores</h3>
+      <div class="section-head">
+        <span class="chip">📦</span>
+        <h3 style="margin:0;">Proveedores</h3>
+      </div>
       <div class="row">
         <label class="w240">
           <span>Proveedor por defecto</span>
@@ -109,38 +107,37 @@
           <input id="otherProvider" class="input" placeholder="Nombre"/>
         </label>
 
-        <label class="w240">
-          <span>Subir catálogo</span>
+        <label class="drop-zone w240">
           <input id="providerCatalog" type="file" />
+          <span>Arrastra o haz clic para subir</span>
         </label>
 
         <button id="btnUploadCatalog" class="btn secondary">Subir archivo</button>
 
         <div class="inline">
           <span>Estado:</span>
-          <span id="catalogStatus" class="badge badge-idle">ℹ️ Sin datos</span>
+          <span id="catalogStatus" class="badge badge-idle" aria-live="polite">ℹ️ Sin datos</span>
         </div>
-
-        <div class="toolbar-right">
-          <button id="btnSaveProvider" class="btn primary">Guardar</button>
-        </div>
+      </div>
+      <div class="toolbar" style="justify-content:flex-end; margin-top: var(--s3);">
+        <button id="btnSaveProvider" class="btn primary">Guardar</button>
       </div>
     </article>
 
     <!-- Documentación y prefijos -->
     <article id="prefijos" class="card">
-      <h3>Documentación y prefijos</h3>
-      <div class="grid" style="grid-template-columns: repeat(2, 1fr);">
-        <div class="grid" style="grid-template-columns: repeat(3, 1fr);">
-          <label>Presupuestos <input id="prefQuote" class="input" placeholder="PRES-2025-"/></label>
-          <label>Facturas <input id="prefInvoice" class="input" placeholder="FACT-"/></label>
-          <label>Partes <input id="prefWork" class="input" placeholder="PAR-"/></label>
-        </div>
-        <div class="grid" style="grid-template-columns: repeat(3, 1fr);">
-          <label>Reset contador Presupuestos <input id="resetQuote" class="input" type="number" placeholder="1"/></label>
-          <label>Reset contador Facturas <input id="resetInvoice" class="input" type="number" placeholder="1"/></label>
-          <label>Reset contador Partes <input id="resetWork" class="input" type="number" placeholder="1"/></label>
-        </div>
+      <div class="section-head">
+        <span class="chip">📑</span>
+        <h3 style="margin:0;">Documentación y prefijos</h3>
+      </div>
+      <div class="grid" style="grid-template-columns: repeat(3, 1fr);">
+        <label>Presupuestos <input id="prefQuote" class="input" placeholder="PRES-2025-"/></label>
+        <label>Facturas <input id="prefInvoice" class="input" placeholder="FACT-"/></label>
+        <label>Partes <input id="prefWork" class="input" placeholder="PAR-"/></label>
+      </div>
+      <div class="inline" style="margin-top:var(--s3); align-items:flex-end;">
+        <label class="w240">Próximo número de presupuesto <input id="nextQuote" class="input" disabled/></label>
+        <button id="btnResetPrefixes" class="btn secondary">Reiniciar numeración</button>
       </div>
       <p class="hint">El siguiente número se recalculará automáticamente al guardar.</p>
       <div class="toolbar" style="justify-content:flex-end;">
@@ -150,7 +147,10 @@
 
     <!-- Datos fiscales -->
     <article id="fiscal" class="card">
-      <h3>Datos fiscales</h3>
+      <div class="section-head">
+        <span class="chip">🏢</span>
+        <h3 style="margin:0;">Datos fiscales</h3>
+      </div>
       <div class="grid" style="grid-template-columns: repeat(2, 1fr);">
         <label>Nombre fiscal <input id="taxName" class="input" /></label>
         <label>NIF/CIF <input id="taxId" class="input" /></label>
@@ -164,27 +164,37 @@
 
     <!-- Branding -->
     <article id="branding" class="card">
-      <h3>Branding de documentos</h3>
+      <div class="section-head">
+        <span class="chip">🎨</span>
+        <h3 style="margin:0;">Branding de documentos</h3>
+      </div>
       <div class="grid" style="grid-template-columns: 1fr 1fr;">
         <div class="wire" style="padding:12px;">
-          <label>Logo <input id="logoFile" type="file" accept="image/*"/></label>
+          <label>Logo</label>
+          <label class="drop-zone" style="margin-top:.4rem;">
+            <input id="logoFile" type="file" accept="image/*"/>
+            <span>Arrastra o haz clic para subir</span>
+          </label>
           <div id="logoPreview" class="preview-box" style="margin-top:.6rem;">
             <span>Vista previa</span>
           </div>
         </div>
         <div>
           <label>Modelo de factura</label>
-          <select id="tplInvoice" class="input">
-            <option value="A">Modelo A</option>
-            <option value="B">Modelo B</option>
-          </select>
+          <div class="inline">
+            <select id="tplInvoice" class="input">
+              <option value="A">Modelo A</option>
+              <option value="B">Modelo B</option>
+            </select>
+            <button id="btnPreviewInvoice" class="btn secondary">Preview</button>
+          </div>
           <label style="margin-top:.6rem;">Modelo de presupuesto</label>
           <div class="inline">
             <select id="tplQuote" class="input">
               <option value="A">Modelo A</option>
               <option value="B">Modelo B</option>
             </select>
-            <button id="btnPreviewBrand" class="btn secondary">Preview</button>
+            <button id="btnPreviewQuote" class="btn secondary">Preview</button>
           </div>
           <div class="toolbar" style="justify-content:flex-end; margin-top: var(--s3);">
             <button id="btnSaveBranding" class="btn primary">Guardar</button>
@@ -195,7 +205,10 @@
 
     <!-- Modelo de email -->
     <article id="email" class="card">
-      <h3>Modelo de email</h3>
+      <div class="section-head">
+        <span class="chip">✉️</span>
+        <h3 style="margin:0;">Modelo de email</h3>
+      </div>
       <label>Asunto <input id="emailSubject" class="input" placeholder="Tu presupuesto {numero}"/></label>
       <label style="margin-top:.6rem;">Cuerpo <span class="help-icon" title="Variables disponibles: {cliente}, {importe}, {enlace}, {numero}">?</span></label>
       <textarea id="emailBody" class="input" placeholder="Hola {cliente}, adjuntamos tu presupuesto por importe {importe}. Enlace: {enlace}"></textarea>
@@ -219,7 +232,7 @@ function setBadge(el, status){
     case 'processing':
       el.classList.add('badge-processing'); el.textContent = '⏳ Procesando'; break;
     case 'ok':
-      el.classList.add('badge-ok'); el.textContent = '✅ Completado'; break;
+      el.classList.add('badge-ok'); el.textContent = '✅ Listo'; break;
     case 'error':
       el.classList.add('badge-error'); el.textContent = '❌ Error'; break;
     default:
@@ -262,6 +275,7 @@ provider.addEventListener('change', () => {
   otherWrap.style.display = provider.value === 'other' ? '' : 'none';
 });
 const catalogStatus = document.getElementById('catalogStatus');
+const btnUploadCatalog = document.getElementById('btnUploadCatalog');
 
 // Branding preview
 const logoFile = document.getElementById('logoFile');
@@ -314,6 +328,7 @@ btnUploadAI.onclick = async () => {
     setBadge(aiStatus,'idle');
     return;
   }
+  btnUploadAI.classList.add('loading'); const old=btnUploadAI.innerHTML; btnUploadAI.innerHTML='<span class="spinner"></span>';
   aiFileStatus.innerHTML = Array.from(aiFiles.files).map(f=>`${f.name} ⏳`).join('<br>');
   setBadge(aiStatus,'processing');
   const fd = new FormData();
@@ -323,6 +338,7 @@ btnUploadAI.onclick = async () => {
   aiUploaded.textContent = j.count ?? 0;
   aiFileStatus.innerHTML = Array.from(aiFiles.files).map(f=>`${f.name} ✅`).join('<br>');
   setBadge(aiStatus, j.status || 'ok');
+  btnUploadAI.classList.remove('loading'); btnUploadAI.innerHTML=old;
 };
 
 btnTrain.onclick = async () => {
@@ -351,37 +367,41 @@ btnResetAI.onclick = async () => {
 btnDownloadModel.onclick = () => { window.location = `${API}/settings/ai/model`; };
 
 // ---- SAVE handlers
-async function saveJSON(url, payload, okMsg){
+async function saveJSON(url, payload, okMsg, btn){
+  let old;
+  if(btn){ btn.classList.add('loading'); old=btn.innerHTML; btn.innerHTML='<span class="spinner"></span>'; }
   const r = await fetch(url, {
     method:'PUT',
     headers:{ 'Content-Type':'application/json' },
     body: JSON.stringify(payload)
   });
+  if(btn){ btn.classList.remove('loading'); btn.innerHTML=old; }
   if(!r.ok){ alert('Error guardando'); return; }
   showToast(okMsg || 'Guardado correctamente');
 }
 
-document.getElementById('btnSaveTariffs').onclick = () => saveJSON(`${API}/settings/tariffs`, {
+document.getElementById('btnSaveTariffs').onclick = function(){ saveJSON(`${API}/settings/tariffs`, {
   rate_hour: +document.getElementById('rateHour').value,
   min_minutes: +document.getElementById('minBlock').value,
   step_minutes: +document.getElementById('stepBlock').value,
   markup_percent: +document.getElementById('markup').value,
   vat_percent: +document.getElementById('vat').value,
   travel_per_km: +document.getElementById('travelKm').value
-}, 'Tarifas guardadas correctamente');
+}, 'Tarifas guardadas correctamente', this); };
 
-document.getElementById('btnSaveProvider').onclick = async () => {
+document.getElementById('btnSaveProvider').onclick = async function(){
   const chosen = provider.value === 'other' ? document.getElementById('otherProvider').value : provider.value;
-  await saveJSON(`${API}/settings/provider`, { default_provider: chosen }, 'Proveedor guardado');
+  await saveJSON(`${API}/settings/provider`, { default_provider: chosen }, 'Proveedor guardado', this);
 };
 
-document.getElementById('btnUploadCatalog').onclick = async () => {
+btnUploadCatalog.onclick = async () => {
   const file = document.getElementById('providerCatalog').files[0];
   if(!file){
     catalogStatus.className='badge badge-error';
     catalogStatus.textContent='❌ No se han proporcionado archivos';
     return;
   }
+  btnUploadCatalog.classList.add('loading'); const old=btnUploadCatalog.innerHTML; btnUploadCatalog.innerHTML='<span class="spinner"></span>';
   catalogStatus.className='badge badge-processing';
   catalogStatus.textContent=`⏳ ${file.name}`;
   const fd = new FormData();
@@ -390,27 +410,23 @@ document.getElementById('btnUploadCatalog').onclick = async () => {
   const j = await r.json();
   catalogStatus.className = j.status === 'error' ? 'badge badge-error' : 'badge badge-ok';
   catalogStatus.textContent = `${j.status === 'error' ? '❌' : '✅'} ${file.name}`;
+  btnUploadCatalog.classList.remove('loading'); btnUploadCatalog.innerHTML=old;
 };
 
-document.getElementById('btnSavePrefixes').onclick = () => saveJSON(`${API}/settings/prefixes`, {
+document.getElementById('btnSavePrefixes').onclick = function(){ saveJSON(`${API}/settings/prefixes`, {
   quote_prefix: document.getElementById('prefQuote').value,
   invoice_prefix: document.getElementById('prefInvoice').value,
-  work_prefix: document.getElementById('prefWork').value,
-  reset: {
-    quote_next: +document.getElementById('resetQuote').value || null,
-    invoice_next: +document.getElementById('resetInvoice').value || null,
-    work_next: +document.getElementById('resetWork').value || null
-  }
-}, 'Prefijos guardados');
+  work_prefix: document.getElementById('prefWork').value
+}, 'Prefijos guardados', this); };
 
-document.getElementById('btnSaveFiscal').onclick = () => saveJSON(`${API}/settings/fiscal`, {
+document.getElementById('btnSaveFiscal').onclick = function(){ saveJSON(`${API}/settings/fiscal`, {
   legal_name: document.getElementById('taxName').value,
   tax_id: document.getElementById('taxId').value,
   address: document.getElementById('taxAddress').value,
   city_zip: document.getElementById('taxCityZip').value
-}, 'Datos fiscales guardados');
+}, 'Datos fiscales guardados', this); };
 
-document.getElementById('btnSaveBranding').onclick = async () => {
+document.getElementById('btnSaveBranding').onclick = async function(){
   // upload logo if selected
   const lf = document.getElementById('logoFile').files[0];
   if(lf){
@@ -420,15 +436,21 @@ document.getElementById('btnSaveBranding').onclick = async () => {
   await saveJSON(`${API}/settings/branding`, {
     invoice_template: document.getElementById('tplInvoice').value,
     quote_template: document.getElementById('tplQuote').value
-  }, 'Branding guardado');
+  }, 'Branding guardado', this);
 };
 
-document.getElementById('btnPreviewBrand').onclick = () => window.open(`${API}/settings/branding/preview`, '_blank');
+document.getElementById('btnPreviewInvoice').onclick = () => window.open(`${API}/settings/branding/preview?type=invoice`, '_blank');
+document.getElementById('btnPreviewQuote').onclick = () => window.open(`${API}/settings/branding/preview?type=quote`, '_blank');
 
-document.getElementById('btnSaveEmail').onclick = () => saveJSON(`${API}/settings/email-template`, {
+document.getElementById('btnSaveEmail').onclick = function(){ saveJSON(`${API}/settings/email-template`, {
   subject: document.getElementById('emailSubject').value,
   body: document.getElementById('emailBody').value
-}, 'Email guardado');
+}, 'Email guardado', this); };
+
+document.getElementById('btnResetPrefixes').onclick = async function(){
+  await fetch(`${API}/settings/prefixes/reset`, { method:'POST' });
+  showToast('Numeración reiniciada');
+};
 
 // ---- Load initial values
 (async function boot(){

--- a/frontend/public/css/style.css
+++ b/frontend/public/css/style.css
@@ -327,6 +327,22 @@ footer a:hover{ text-decoration:underline; }
 .toolbar { display:flex; gap:var(--s3); flex-wrap:wrap; align-items:center; }
 .toolbar .input, .toolbar select { padding:8px 10px; border:1px solid var(--border); border-radius:8px; background:#fff; }
 
+.breadcrumb{ margin-bottom:var(--s3); font-size:.9rem; }
+.page-title{ font-size:2rem; margin:0; }
+.page-desc{ margin-top:.2rem; margin-bottom:var(--s5); color:var(--muted); }
+.badge{ display:inline-block; padding:2px 8px; border-radius:8px; font-size:.85rem; }
+.badge-idle{ background:#e5e7eb; color:#374151; }
+.badge-processing{ background:#facc15; color:#78350f; }
+.badge-ok{ background:#86efac; color:#064e3b; }
+.badge-error{ background:#fca5a5; color:#7f1d1d; }
+.toast{ position:fixed; bottom:20px; right:20px; background:#111; color:#fff; padding:10px 16px; border-radius:8px; opacity:0; transition:opacity .3s, transform .3s; transform:translateY(20px); z-index:1000; }
+.toast.show{ opacity:1; transform:translateY(0); }
+.help-icon{ display:inline-block; width:18px; height:18px; border-radius:50%; background:var(--sky); color:#fff; text-align:center; line-height:18px; font-size:.75rem; cursor:help; margin-left:.3rem; }
+.file-list{ margin-top:.6rem; font-size:.9rem; }
+.input, select.input, textarea.input{ padding:8px 10px; border:1px solid var(--border); border-radius:8px; font:inherit; }
+#emailBody{ min-height:120px; }
+#emailBody::placeholder, #emailSubject::placeholder{ font-family:monospace; }
+
 .upgrade { background:rgba(37,99,235,.06); border:1px dashed rgba(37,99,235,.4); padding:var(--s4); border-radius: var(--radius); }
 
 body.index .hero .btn.primary {

--- a/frontend/public/css/style.css
+++ b/frontend/public/css/style.css
@@ -320,7 +320,7 @@ footer a:hover{ text-decoration:underline; }
 .kpi .title{ color:var(--muted); font-size:.9rem; }
 .kpi .value{ font-weight:800; font-size:1.6rem; }
 
-.card { background:var(--paper); border:1px solid var(--border); border-radius:var(--radius); padding:var(--s5); }
+.card { background:var(--paper); border:1px solid var(--border); border-radius:var(--radius); padding:var(--s5); margin-bottom:var(--s6); }
 .card h3 { margin-top:0 }
 .table { width:100%; border-collapse: collapse; }
 .table th, .table td { border-bottom:1px solid var(--border); padding:10px; text-align:left; }
@@ -329,7 +329,7 @@ footer a:hover{ text-decoration:underline; }
 
 .breadcrumb{ margin-bottom:var(--s3); font-size:.9rem; }
 .page-title{ font-size:2rem; margin:0; }
-.page-desc{ margin-top:.2rem; margin-bottom:var(--s5); color:var(--muted); }
+.page-desc{ margin-top:.2rem; margin-bottom:var(--s5); color:var(--muted); font-size:.95rem; }
 .badge{ display:inline-block; padding:2px 8px; border-radius:8px; font-size:.85rem; }
 .badge-idle{ background:#e5e7eb; color:#374151; }
 .badge-processing{ background:#facc15; color:#78350f; }
@@ -340,8 +340,20 @@ footer a:hover{ text-decoration:underline; }
 .help-icon{ display:inline-block; width:18px; height:18px; border-radius:50%; background:var(--sky); color:#fff; text-align:center; line-height:18px; font-size:.75rem; cursor:help; margin-left:.3rem; }
 .file-list{ margin-top:.6rem; font-size:.9rem; }
 .input, select.input, textarea.input{ padding:8px 10px; border:1px solid var(--border); border-radius:8px; font:inherit; }
+.input:focus, select.input:focus, textarea.input:focus{ outline:2px solid var(--sky); outline-offset:2px; }
 #emailBody{ min-height:120px; }
 #emailBody::placeholder, #emailSubject::placeholder{ font-family:monospace; }
+
+/* File drop zones */
+.drop-zone{ position:relative; border:2px dashed var(--border); border-radius:var(--radius-sm); padding:var(--s4); text-align:center; color:var(--muted); cursor:pointer; }
+.drop-zone input{ position:absolute; inset:0; width:100%; height:100%; opacity:0; cursor:pointer; }
+
+/* Buttons */
+.btn.secondary{ background:#f3f4f6; color:var(--steel); border:1px solid var(--border); box-shadow:none; }
+.btn.secondary:hover{ background:#e5e7eb; }
+.btn.secondary:active{ background:#d1d5db; }
+.btn.loading{ pointer-events:none; opacity:.7; }
+.btn.loading .spinner{ margin-right:6px; }
 
 .upgrade { background:rgba(37,99,235,.06); border:1px dashed rgba(37,99,235,.4); padding:var(--s4); border-radius: var(--radius); }
 


### PR DESCRIPTION
## Summary
- add breadcrumb navigation and page description to settings
- show file upload status with badges and toast notifications
- add email template preview with placeholders and help tooltip

## Testing
- `pytest` *(fails: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b97036ea388325a7e9aaa1a989fa4f