### PR TITLE
Add dashboard widget loading states and placeholders

### DIFF
--- a/frontend/pages/dashboard.html
+++ b/frontend/pages/dashboard.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Dashboard · FixHub</title>
   <link rel="stylesheet" href="/css/style.css?v={cachebust}"/>
+  <script src="/js/dashboard.js" defer></script>
 </head>
 <body>
 <!--#include "partials/header.html" -->
@@ -13,41 +14,82 @@
   <h2>Dashboard</h2>
 
   <section class="kpis">
-    <div class="kpi">
-      <div class="title">Facturación (mes)</div>
-      <div class="value">— €</div>
+    <div class="kpi" data-widget="kpi-billing" data-state="loading">
+      <div class="title"><span class="icon" aria-hidden="true">💶</span>Facturación (mes)</div>
+      <div class="value" aria-live="polite">
+        <span class="data">0&nbsp;€</span>
+        <span class="skeleton"></span>
+        <span data-role="empty">Sin datos</span>
+        <span data-role="error">⚠️ Error <button class="retry">Reintentar</button></span>
+      </div>
     </div>
-    <div class="kpi">
-      <div class="title">Trabajos hoy</div>
-      <div class="value">—</div>
+    <div class="kpi" data-widget="kpi-jobs" data-state="loading">
+      <div class="title"><span class="icon" aria-hidden="true">📋</span>Trabajos hoy</div>
+      <div class="value" aria-live="polite">
+        <span class="data">0</span>
+        <span class="skeleton"></span>
+        <span data-role="empty">Sin datos</span>
+        <span data-role="error">⚠️ Error <button class="retry">Reintentar</button></span>
+      </div>
     </div>
-    <div class="kpi">
-      <div class="title">Tiempo real vs. presup.</div>
-      <div class="value">—%</div>
+    <div class="kpi" data-widget="kpi-time" data-state="loading">
+      <div class="title"><span class="icon" aria-hidden="true">⏱️</span>Tiempo real vs. presup.</div>
+      <div class="value" aria-live="polite">
+        <span class="data">0%</span>
+        <span class="skeleton"></span>
+        <span data-role="empty">Sin datos</span>
+        <span data-role="error">⚠️ Error <button class="retry">Reintentar</button></span>
+      </div>
     </div>
-    <div class="kpi">
-      <div class="title">Valoración media</div>
-      <div class="value">— ★</div>
+    <div class="kpi" data-widget="kpi-rating" data-state="loading">
+      <div class="title"><span class="icon" aria-hidden="true">⭐</span>Valoración media</div>
+      <div class="value" aria-live="polite">
+        <span class="data">0 ★</span>
+        <span class="skeleton"></span>
+        <span data-role="empty">Sin datos</span>
+        <span data-role="error">⚠️ Error <button class="retry">Reintentar</button></span>
+      </div>
     </div>
   </section>
 
   <section class="grid" style="grid-template-columns: 2fr 1fr;">
-    <div class="card wire">
+    <div class="card wire chart" data-widget="chart-billing" data-state="loading">
       <h3>Evolución de facturación</h3>
-      <div style="height:260px;"></div>
+      <div class="chart-area" style="height:260px;">
+        <div class="chart-placeholder" data-role="slow"></div>
+        <div class="chart-empty">Sin registros suficientes</div>
+        <div class="chart-error">No se pudo cargar el gráfico <button class="retry">Reintentar</button></div>
+        <div class="chart-content"></div>
+      </div>
     </div>
-    <div class="card wire">
+    <div class="card wire chart" data-widget="chart-jobs" data-state="loading">
       <h3>Trabajos por empleado</h3>
-      <div style="height:260px;"></div>
+      <div class="chart-area" style="height:260px;">
+        <div class="chart-placeholder" data-role="slow"></div>
+        <div class="chart-empty">Sin registros suficientes</div>
+        <div class="chart-error">No se pudo cargar el gráfico <button class="retry">Reintentar</button></div>
+        <div class="chart-content"></div>
+      </div>
     </div>
   </section>
 
-  <section class="card wire" style="margin-top: var(--s5);">
+  <section class="card wire" style="margin-top: var(--s5);" data-widget="table-jobs" data-state="loading">
     <h3>Tiempo estimado vs. real (últimos trabajos)</h3>
-    <table class="table">
-      <thead><tr><th>Trabajo</th><th>Empleado</th><th>Estimado</th><th>Real</th><th>Δ</th></tr></thead>
-      <tbody><tr><td>—</td><td>—</td><td>—</td><td>—</td><td>—</td></tr></tbody>
-    </table>
+    <div class="table-wrapper">
+      <table class="table">
+        <thead><tr><th>Trabajo</th><th>Empleado</th><th>Estimado</th><th>Real</th><th>Δ</th></tr></thead>
+        <tbody class="tbody-skeleton">
+          <tr><td><span class="skeleton" style="width:80%"></span></td><td><span class="skeleton" style="width:60%"></span></td><td><span class="skeleton" style="width:50%"></span></td><td><span class="skeleton" style="width:50%"></span></td><td><span class="skeleton" style="width:30%"></span></td></tr>
+          <tr><td><span class="skeleton" style="width:80%"></span></td><td><span class="skeleton" style="width:60%"></span></td><td><span class="skeleton" style="width:50%"></span></td><td><span class="skeleton" style="width:50%"></span></td><td><span class="skeleton" style="width:30%"></span></td></tr>
+          <tr><td><span class="skeleton" style="width:80%"></span></td><td><span class="skeleton" style="width:60%"></span></td><td><span class="skeleton" style="width:50%"></span></td><td><span class="skeleton" style="width:50%"></span></td><td><span class="skeleton" style="width:30%"></span></td></tr>
+        </tbody>
+        <tbody class="tbody-data">
+          <tr><td>—</td><td>—</td><td>—</td><td>—</td><td>—</td></tr>
+        </tbody>
+        <tbody class="tbody-empty"><tr><td colspan="5" class="center" data-role="empty">Sin datos para mostrar</td></tr></tbody>
+        <tbody class="tbody-error"><tr><td colspan="5" class="center" data-role="error">No se pudo cargar la información <button class="retry">Reintentar</button></td></tr></tbody>
+      </table>
+    </div>
   </section>
 </main>
 

--- a/frontend/public/css/style.css
+++ b/frontend/public/css/style.css
@@ -369,3 +369,58 @@ body.index .hero .btn.tertiary {
   font-weight:600;
   color: var(--ink);
 }
+
+/* --- Dashboard state helpers --- */
+.skeleton{
+  background: var(--border);
+  border-radius:4px;
+  animation: skeleton 1.2s ease-in-out infinite;
+}
+@keyframes skeleton{
+  0%,100%{opacity:.5;}
+  50%{opacity:1;}
+}
+.kpi .title .icon{ margin-right:4px; }
+
+.kpi[data-state="loading"] .data,
+.kpi[data-state="empty"] .data,
+.kpi[data-state="error"] .data{ display:none; }
+.kpi[data-state="loading"] .skeleton{ display:inline-block; height:1.6rem; width:60%; }
+.kpi[data-state="success"] .skeleton,
+.kpi[data-state="empty"] .skeleton,
+.kpi[data-state="error"] .skeleton{ display:none; }
+.kpi[data-state="empty"] [data-role="empty"]{ display:inline; color:var(--muted); }
+.kpi[data-state="error"] [data-role="error"]{ display:inline; color:var(--rose); }
+.kpi [data-role="empty"],
+.kpi [data-role="error"]{ display:none; }
+
+.card.chart{ position:relative; }
+.card.chart .chart-area{ position:relative; }
+.card.chart .chart-placeholder,
+.card.chart .chart-empty,
+.card.chart .chart-error{
+  position:absolute; inset:0;
+  display:flex; align-items:center; justify-content:center;
+  color:var(--muted); background:var(--paper);
+}
+.card.chart .chart-placeholder,
+.card.chart .chart-empty,
+.card.chart .chart-error{ display:none; text-align:center; }
+.card.chart[data-state="loading"] .chart-placeholder{ display:flex; }
+.card.chart[data-state="empty"] .chart-empty{ display:flex; }
+.card.chart[data-state="error"] .chart-error{ display:flex; }
+.card.chart[data-state="success"] .chart-content{ display:block; }
+.card.chart .chart-content{ display:none; height:100%; }
+
+[data-widget][data-state="loading"] .tbody-skeleton{ display:table-row-group; }
+[data-widget][data-state="loading"] .tbody-data,
+[data-widget][data-state="empty"] .tbody-data,
+[data-widget][data-state="error"] .tbody-data{ display:none; }
+[data-widget][data-state="empty"] .tbody-empty{ display:table-row-group; }
+[data-widget][data-state="error"] .tbody-error{ display:table-row-group; }
+[data-widget][data-state="success"] .tbody-data{ display:table-row-group; }
+.table-wrapper .tbody-skeleton,
+.table-wrapper .tbody-empty,
+.table-wrapper .tbody-error{ display:none; }
+[data-role="error"]{ color:var(--rose); }
+[data-role="empty"]{ color:var(--muted); }

--- a/frontend/public/js/dashboard.js
+++ b/frontend/public/js/dashboard.js
@@ -1,0 +1,33 @@
+(function(){
+  function setState(widget, state){
+    widget.dataset.state = state;
+    if(state === 'loading'){
+      const placeholder = widget.querySelector('[data-role="slow"]');
+      if(placeholder){
+        placeholder.textContent = 'Cargando datos…';
+        widget._slowTimer = setTimeout(()=>{
+          if(widget.dataset.state === 'loading'){
+            placeholder.textContent = 'Tarda más de lo habitual…';
+          }
+        }, 10000);
+      }
+    } else if(widget._slowTimer){
+      clearTimeout(widget._slowTimer);
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', ()=>{
+    document.querySelectorAll('[data-widget]').forEach(widget=>{
+      widget.setAttribute('tabindex','-1');
+      const retry = widget.querySelector('.retry');
+      if(retry){
+        retry.addEventListener('click', e=>{
+          e.preventDefault();
+          setState(widget, 'loading');
+          setTimeout(()=>setState(widget, 'success'), 800);
+          widget.focus();
+        });
+      }
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
- add skeleton-based loading, empty, and error states for dashboard KPI cards, charts, and table
- style new dashboard states and icons
- implement JS helper for retry and slow-loading messaging

## Testing
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9714401ac832584854613e41a5f59