### PR TITLE
Preselect registration plan based on pricing choice

### DIFF
--- a/frontend/pages/pricing.html
+++ b/frontend/pages/pricing.html
@@ -127,7 +127,7 @@
         <li class="unavailable">Facturación electrónica</li>
       </ul>
       <div class="card-cta">
-        <a id="freeBtn" class="btn primary" href="./register.html">Empieza gratis</a>
+        <a id="freeBtn" class="btn primary" href="./register.html?plan=Trial">Empieza gratis</a>
       </div>
       <a class="hint">* Pago integrado con comisiones del 10% en plan gratuito</a>
     </article>
@@ -263,7 +263,7 @@ import { pricePerSeatFromTiers, computeAnnual } from '/js/pricing-lib.js';
       freePrice.textContent = '0';
       freePeriod.textContent = '/ 2 meses';
       freeBtn.textContent = 'Empieza gratis';
-      freeBtn.setAttribute('href','./login.html');
+      freeBtn.setAttribute('href','./register.html?plan=Trial');
     } else {
       freeCard.classList.add('disabled');
       freePrice.textContent = '—';

--- a/frontend/pages/pricing.html
+++ b/frontend/pages/pricing.html
@@ -146,7 +146,7 @@
         <li>Soporte estándar</li>
       </ul>
       <div class="card-cta">
-        <a class="btn secondary" href="./register.html">Elegir plan Solo</a>
+        <a class="btn secondary" href="./register.html?plan=Solo">Elegir plan Solo</a>
       </div>
       <a class="hint">* Pago integrado con comisiones del 5% en plan Solo</a>
     </article>
@@ -178,7 +178,7 @@
         <li>Próximamente: métricas y SLA</li>
       </ul>
       <div class="card-cta">
-        <a class="btn primary" href="./register.html">Crear equipo</a>
+        <a id="teamBtn" class="btn primary" href="./register.html?plan=Team&seats=3">Crear equipo</a>
       </div>
       <a class="hint">* Pago integrado con comisiones del 5% en plan Team</a>
     </article>
@@ -245,6 +245,7 @@ import { pricePerSeatFromTiers, computeAnnual } from '/js/pricing-lib.js';
   const teamPriceNum = document.getElementById('teamPriceNum');
   const teamPeriodEl = document.getElementById('teamPeriod');
   const teamNoteEl   = document.getElementById('teamNote');
+  const teamBtn      = document.getElementById('teamBtn');
 
   // Precio por asiento mensual (según tamaño)
   function perSeatPrice(n){
@@ -299,6 +300,7 @@ import { pricePerSeatFromTiers, computeAnnual } from '/js/pricing-lib.js';
       teamPeriodEl.textContent = '/ año*';
       teamNoteEl.innerHTML = 'Equivale a <strong>'+fmt(seat*(1-PRICING.annualDiscount))+'€</strong> / persona / mes (−'+(PRICING.annualDiscount*100)+'% anual).';
     }
+    teamBtn.setAttribute('href', './register.html?plan=Team&seats=' + n);
   }
 
   // --- Toggle ---

--- a/frontend/pages/pricing.html
+++ b/frontend/pages/pricing.html
@@ -127,7 +127,7 @@
         <li class="unavailable">Facturación electrónica</li>
       </ul>
       <div class="card-cta">
-        <a id="freeBtn" class="btn primary" href="./register.html?plan=Trial">Empieza gratis</a>
+        <a id="freeBtn" class="btn primary" href="./register.html?planVal=demoM">Empieza gratis</a>
       </div>
       <a class="hint">* Pago integrado con comisiones del 10% en plan gratuito</a>
     </article>
@@ -146,7 +146,7 @@
         <li>Soporte estándar</li>
       </ul>
       <div class="card-cta">
-        <a class="btn secondary" href="./register.html?plan=Solo">Elegir plan Solo</a>
+        <a id="soloBtn" class="btn secondary" href="./register.html?planVal=soloM">Elegir plan Solo</a>
       </div>
       <a class="hint">* Pago integrado con comisiones del 5% en plan Solo</a>
     </article>
@@ -178,7 +178,7 @@
         <li>Próximamente: métricas y SLA</li>
       </ul>
       <div class="card-cta">
-        <a id="teamBtn" class="btn primary" href="./register.html?plan=Team&seats=3">Crear equipo</a>
+        <a id="teamBtn" class="btn primary" href="./register.html?planVal=teamM&seats=3">Crear equipo</a>
       </div>
       <a class="hint">* Pago integrado con comisiones del 5% en plan Team</a>
     </article>
@@ -239,6 +239,7 @@ import { pricePerSeatFromTiers, computeAnnual } from '/js/pricing-lib.js';
   let soloMonthly = PRICING.solo.monthly;
   const soloPriceEl  = document.getElementById('soloPrice');
   const soloPeriodEl = document.getElementById('soloPeriod');
+  const soloBtn      = document.getElementById('soloBtn');
 
   // ---- TEAM ----
   const teamSizeEl   = document.getElementById('teamSize');
@@ -263,7 +264,7 @@ import { pricePerSeatFromTiers, computeAnnual } from '/js/pricing-lib.js';
       freePrice.textContent = '0';
       freePeriod.textContent = '/ 2 meses';
       freeBtn.textContent = 'Empieza gratis';
-      freeBtn.setAttribute('href','./register.html?plan=Trial');
+      freeBtn.setAttribute('href','./register.html?planVal=demoM');
     } else {
       freeCard.classList.add('disabled');
       freePrice.textContent = '—';
@@ -275,6 +276,7 @@ import { pricePerSeatFromTiers, computeAnnual } from '/js/pricing-lib.js';
 
   // --- Actualiza SOLO ---
   function updateSolo(){
+    const suf = billing === YEARLY ? 'A' : 'M';
     if (billing === MONTHLY){
       soloPriceEl.textContent = fmt(soloMonthly);
       soloPeriodEl.textContent = '/ mes*';
@@ -282,6 +284,7 @@ import { pricePerSeatFromTiers, computeAnnual } from '/js/pricing-lib.js';
       soloPriceEl.textContent = fmt(yearlyTotal(soloMonthly));
       soloPeriodEl.textContent = '/ año*';
     }
+    soloBtn.setAttribute('href', `./register.html?planVal=solo${suf}`);
   }
 
   // --- Actualiza TEAM ---
@@ -290,6 +293,7 @@ import { pricePerSeatFromTiers, computeAnnual } from '/js/pricing-lib.js';
     const seat = perSeatPrice(n);
     const mTotal = n * seat;
 
+    const suf = billing === YEARLY ? 'A' : 'M';
     if (billing === MONTHLY){
       teamPriceNum.textContent = fmt(mTotal);
       teamPeriodEl.textContent = '/ mes*';
@@ -300,7 +304,7 @@ import { pricePerSeatFromTiers, computeAnnual } from '/js/pricing-lib.js';
       teamPeriodEl.textContent = '/ año*';
       teamNoteEl.innerHTML = 'Equivale a <strong>'+fmt(seat*(1-PRICING.annualDiscount))+'€</strong> / persona / mes (−'+(PRICING.annualDiscount*100)+'% anual).';
     }
-    teamBtn.setAttribute('href', './register.html?plan=Team&seats=' + n);
+    teamBtn.setAttribute('href', `./register.html?planVal=team${suf}&seats=${n}`);
   }
 
   // --- Toggle ---

--- a/frontend/pages/register.html
+++ b/frontend/pages/register.html
@@ -243,13 +243,24 @@
   const modalBackdrop = document.getElementById('modalBackdrop');
   const modalCancel = document.getElementById('modalCancel');
 
-  // Preselect plan via query params
+  // Preselect plan & billing via query params
   const urlParams = new URLSearchParams(window.location.search);
-  const prePlan = urlParams.get('plan');
+  const planValParam = urlParams.get('planVal');
   const preSeats = urlParams.get('seats');
-  if (prePlan) {
-    const r = Array.from(planRadios).find(p => p.value === prePlan);
-    if (r) r.checked = true;
+  let billingCode = 'M';
+  if (planValParam) {
+    const code = planValParam.toLowerCase();
+    const letter = code.slice(-1);
+    billingCode = letter === 'a' ? 'A' : 'M';
+    const base = code.slice(0, -1);
+    let plan;
+    if (base === 'team') plan = 'Team';
+    else if (base === 'solo') plan = 'Solo';
+    else if (base === 'demo') plan = 'Trial';
+    if (plan) {
+      const r = Array.from(planRadios).find(p => p.value === plan);
+      if (r) r.checked = true;
+    }
   }
   if (preSeats) {
     teamSeats.value = preSeats;
@@ -259,11 +270,6 @@
   function isProSelected(){
     const v = document.querySelector('input[name="plan"]:checked').value;
     return v === 'Solo' || v === 'Team';
-  }
-  function planValue(){
-    const v = document.querySelector('input[name="plan"]:checked').value;
-    if (v === 'Team') return `Team_${teamSeats.value}`;
-    return v; // Trial o Solo
   }
   function showError(msg){
     alertBox.textContent = msg;
@@ -404,10 +410,12 @@
     }
 
     // Build payload
-    const planVal = document.querySelector('input[name="plan"]:checked').value;
+    const planSel = document.querySelector('input[name="plan"]:checked').value;
+    const base = planSel === 'Trial' ? 'demo' : planSel.toLowerCase();
+    const planVal = `${base}${billingCode}`;
     const payload = {
       license: planVal,
-      team_members: planVal === 'Team' ? parseInt(teamSeats.value, 10) : 1,
+      team_members: planSel === 'Team' ? parseInt(teamSeats.value, 10) : 1,
       email: document.getElementById('email').value.trim(),
       telephone: document.getElementById('phone').value.trim(),
       first_name: document.getElementById('name').value.trim(),

--- a/frontend/pages/register.html
+++ b/frontend/pages/register.html
@@ -243,6 +243,18 @@
   const modalBackdrop = document.getElementById('modalBackdrop');
   const modalCancel = document.getElementById('modalCancel');
 
+  // Preselect plan via query params
+  const urlParams = new URLSearchParams(window.location.search);
+  const prePlan = urlParams.get('plan');
+  const preSeats = urlParams.get('seats');
+  if (prePlan) {
+    const r = Array.from(planRadios).find(p => p.value === prePlan);
+    if (r) r.checked = true;
+  }
+  if (preSeats) {
+    teamSeats.value = preSeats;
+  }
+
   // ----- Helpers
   function isProSelected(){
     const v = document.querySelector('input[name="plan"]:checked').value;


### PR DESCRIPTION
## Summary
- Include selected plan (and team seats) in pricing page links
- Preselect plan and team size on registration form using query params

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'email_validator')*


------
https://chatgpt.com/codex/tasks/task_e_68bdc31189448325ac085cb543b70121