### PR TITLE
Add backend contact logging and email support

### DIFF
--- a/backend/api/routers/contact.py
+++ b/backend/api/routers/contact.py
@@ -1,23 +1,71 @@
+from datetime import datetime
+from email.message import EmailMessage
+import os
+from pathlib import Path
+import smtplib
+
 from fastapi import APIRouter
-from pydantic import BaseModel, EmailStr, constr
+from pydantic import BaseModel, EmailStr, ConfigDict, Field, constr
 
 router = APIRouter(prefix="/api-v1/contact", tags=["contact"])
 
+CONTACT_FILE = Path(__file__).resolve().parents[3] / "contact.txt"
+RECIPIENT_EMAIL = "opotek+fixhub@protonmail.com"
+
+EMAIL_ADDRESS = os.getenv("EMAIL_ADDRESS", "t39474115@gmail.com")
+EMAIL_PASSWORD = os.getenv("EMAIL_PASSWORD", "dvmk zoyl liam aoof")
+SMTP_SERVER = os.getenv("SMTP_SERVER", "smtp.gmail.com")
+SMTP_PORT = int(os.getenv("SMTP_PORT", "587"))
+SENDER = os.getenv("EMAIL_FROM", EMAIL_ADDRESS)
+SUBJECT = os.getenv(
+    "EMAIL_SUBJECT", f"Contact for Fixhub - {datetime.now().date()}"
+)
+
 
 class ContactRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     name: constr(min_length=1)
     email: EmailStr
     message: constr(min_length=1)
-    device_id: constr(min_length=1)
+    device_id: constr(min_length=1) = Field(..., alias="deviceId")
+
+
+def append_to_file(contact: ContactRequest) -> None:
+    """Append the contact message to the contact.txt file."""
+    log_entry = (
+        f"{datetime.utcnow().isoformat()} | {contact.name} <{contact.email}> | "
+        f"{contact.device_id} | {contact.message.replace('\n', ' ').replace('\r', ' ')}\n"
+    )
+    try:
+        with CONTACT_FILE.open("a", encoding="utf-8") as f:
+            f.write(log_entry)
+    except Exception as exc:
+        # Fail silently but log to stderr for debugging
+        print(f"Failed to write contact log: {exc}")
 
 
 def send_email(name: str, email: str, message: str, device_id: str) -> None:
-    """Stub function to simulate sending an email."""
-    # In a real implementation, integrate with an email service here.
-    print(f"Email from {name} <{email}>: {message} (device {device_id})")
+    """Send an email with the contact message to the configured recipient."""
+    msg = EmailMessage()
+    msg["Subject"] = SUBJECT
+    msg["From"] = SENDER
+    msg["To"] = RECIPIENT_EMAIL
+    msg.set_content(
+        f"Name: {name}\nEmail: {email}\nDevice: {device_id}\n\n{message}"
+    )
+
+    if SMTP_SERVER and EMAIL_ADDRESS and EMAIL_PASSWORD and SENDER:
+        with smtplib.SMTP(SMTP_SERVER, SMTP_PORT) as server:
+            server.starttls()
+            server.login(EMAIL_ADDRESS, EMAIL_PASSWORD)
+            server.send_message(msg)
+    else:
+        print("Email not sent. SMTP configuration is missing.")
 
 
 @router.post("")
 def send_contact_form(contact: ContactRequest):
+    append_to_file(contact)
     send_email(contact.name, contact.email, contact.message, contact.device_id)
     return {"status": "ok"}

--- a/frontend/pages/about.html
+++ b/frontend/pages/about.html
@@ -164,7 +164,43 @@
         </form>
       </article>
     </section>
-  </main>
-    <!--# include virtual="/partials/footer.html" -->
-  </body>
-</html>
+    </main>
+      <!--# include virtual="/partials/footer.html" -->
+    <script src="/js/apiClient.js"></script>
+    <script>
+      const form = document.getElementById('aboutForm');
+      const msgEl = document.getElementById('formMsg');
+
+      function ensureDeviceId() {
+        if (!localStorage.getItem('deviceId')) {
+          const newId = self.crypto?.randomUUID ? self.crypto.randomUUID() : Math.random().toString(36).slice(2);
+          localStorage.setItem('deviceId', newId);
+        }
+        return localStorage.getItem('deviceId');
+      }
+
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        msgEl.textContent = '';
+        if (document.getElementById('website').value) {
+          return; // honeypot field
+        }
+        ensureDeviceId();
+        const name = document.getElementById('name').value.trim();
+        const email = document.getElementById('email').value.trim();
+        const reason = document.getElementById('reason').value;
+        const message = document.getElementById('message').value.trim();
+        const fullMessage = reason ? `[${reason}] ${message}` : message;
+        try {
+          await apiClient.post('contact', { name, email, message: fullMessage });
+          form.reset();
+          msgEl.style.color = 'green';
+          msgEl.textContent = 'Mensaje enviado correctamente.';
+        } catch (err) {
+          msgEl.style.color = 'red';
+          msgEl.textContent = err.message || 'No se pudo enviar el mensaje.';
+        }
+      });
+    </script>
+    </body>
+  </html>

--- a/frontend/pages/contact.html
+++ b/frontend/pages/contact.html
@@ -60,12 +60,11 @@
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
     status.textContent = '';
-    const deviceId = ensureDeviceId();
+    ensureDeviceId();
     const data = {
       name: document.getElementById('name').value.trim(),
       email: document.getElementById('email').value.trim(),
       message: document.getElementById('msg').value.trim(),
-      deviceId
     };
     try {
       await apiClient.post('contact', data);


### PR DESCRIPTION
## Summary
- log contact messages to contact.txt and send email to opotek+fixhub@protonmail.com via env-configurable Gmail credentials
- hook up contact and about forms to backend contact endpoint

## Testing
- ⚠️ `pip install email-validator` *(ProxyError: Could not find a version that satisfies the requirement)*
- ⚠️ `pytest` *(ImportError: email-validator is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c017118d008325a8a4285ad79bff81