### PR TITLE
refactor(frontend): unify API endpoints to /api-v1

### DIFF
--- a/frontend/pages/settings.html
+++ b/frontend/pages/settings.html
@@ -212,7 +212,6 @@
 <!--# include virtual="/partials/footer.html" -->
 
 <script>
-const API = location.origin.replace(/\/$/, ''); // adjust if FE+BE on different hosts
 
 // Fill 5' steps (5..120)
 function fillSteps(sel){
@@ -309,7 +308,7 @@ document.getElementById('btnSaveTariffs').onclick = () => saveJSON(`/api-v1/sett
 
 document.getElementById('btnSaveProvider').onclick = async () => {
   const chosen = provider.value === 'other' ? document.getElementById('otherProvider').value : provider.value;
-  await saveJSON(`${API}/settings/provider`, { default_provider: chosen });
+  await saveJSON(`/api-v1/settings/provider`, { default_provider: chosen });
 };
 
 document.getElementById('btnUploadCatalog').onclick = async () => {
@@ -317,12 +316,12 @@ document.getElementById('btnUploadCatalog').onclick = async () => {
   const file = document.getElementById('providerCatalog').files[0];
   if(!file) return alert('Selecciona un archivo');
   fd.append('file', file);
-  const r = await fetch(`/settings/provider/catalog`, { method:'POST', body: fd });
+  const r = await fetch(`/api-v1/settings/provider/catalog`, { method:'POST', body: fd });
   const j = await r.json();
   document.getElementById('catalogStatus').value = j.status || 'procesado';
 };
 
-document.getElementById('btnSavePrefixes').onclick = () => saveJSON(`${API}/settings/prefixes`, {
+document.getElementById('btnSavePrefixes').onclick = () => saveJSON(`/api-v1/settings/prefixes`, {
   quote_prefix: document.getElementById('prefQuote').value,
   invoice_prefix: document.getElementById('prefInvoice').value,
   work_prefix: document.getElementById('prefWork').value,
@@ -333,7 +332,7 @@ document.getElementById('btnSavePrefixes').onclick = () => saveJSON(`${API}/sett
   }
 });
 
-document.getElementById('btnSaveFiscal').onclick = () => saveJSON(`${API}/settings/fiscal`, {
+document.getElementById('btnSaveFiscal').onclick = () => saveJSON(`/api-v1/settings/fiscal`, {
   legal_name: document.getElementById('taxName').value,
   tax_id: document.getElementById('taxId').value,
   address: document.getElementById('taxAddress').value,
@@ -345,17 +344,17 @@ document.getElementById('btnSaveBranding').onclick = async () => {
   const lf = document.getElementById('logoFile').files[0];
   if(lf){
     const fd = new FormData(); fd.append('file', lf);
-    await fetch(`${API}/settings/branding/logo`, { method:'POST', body: fd });
+    await fetch(`/api-v1/settings/branding/logo`, { method:'POST', body: fd });
   }
-  await saveJSON(`${API}/settings/branding`, {
+  await saveJSON(`/api-v1/settings/branding`, {
     invoice_template: document.getElementById('tplInvoice').value,
     quote_template: document.getElementById('tplQuote').value
   });
 };
 
-document.getElementById('btnPreviewBrand').onclick = () => window.open(`${API}/settings/branding/preview`, '_blank');
+document.getElementById('btnPreviewBrand').onclick = () => window.open(`/api-v1/settings/branding/preview`, '_blank');
 
-document.getElementById('btnSaveEmail').onclick = () => saveJSON(`${API}/settings/email-template`, {
+document.getElementById('btnSaveEmail').onclick = () => saveJSON(`/api-v1/settings/email-template`, {
   subject: document.getElementById('emailSubject').value,
   body: document.getElementById('emailBody').value
 });
@@ -363,7 +362,7 @@ document.getElementById('btnSaveEmail').onclick = () => saveJSON(`${API}/setting
 // ---- Load initial values
 (async function boot(){
   try{
-    const r = await fetch(`${API}/settings`);
+    const r = await fetch(`/api-v1/settings`);
     if(!r.ok) return;
     const s = await r.json();
 

--- a/frontend/pages/team.html
+++ b/frontend/pages/team.html
@@ -169,7 +169,6 @@
 import { formatEUR, computeTeamMonthly } from '/js/pricing-lib.js';
 
 /* ====== Config ====== */
-const API_PREFIX = '/api-v1'; // <-- requerido
 const token = localStorage.getItem('token') || '';
 
 let PRICING = null;
@@ -224,7 +223,7 @@ function hide(el){ el.style.display='none'; el.setAttribute('aria-hidden','true'
 /* ====== Load Org & Team ====== */
 async function loadOrg(){
   try{
-    const res = await fetch(`${API_PREFIX}/org/me`, { headers: authHeaders() });
+    const res = await fetch(`/api-v1/org/me`, { headers: authHeaders() });
     if(!res.ok) throw new Error('org');
     const data = await res.json();
     org = {
@@ -243,7 +242,7 @@ async function loadOrg(){
 async function loadTeam(){
   if (!org.id || org.plan.toLowerCase()!=='team') return renderTeam(true);
   try{
-    const res = await fetch(`${API_PREFIX}/team?orgId=${encodeURIComponent(org.id)}`, { headers: authHeaders() });
+    const res = await fetch(`/api-v1/team?orgId=${encodeURIComponent(org.id)}`, { headers: authHeaders() });
     if(!res.ok) throw new Error('team');
     const data = await res.json();
     team = Array.isArray(data?.items) ? data.items : [];
@@ -344,13 +343,13 @@ $('modalMember').addEventListener('click', e=>{ if (e.target.id==='modalMember')
 async function saveMember(payload){
   try{
     if (payload.id){
-      const res = await fetch(`${API_PREFIX}/team/${encodeURIComponent(payload.id)}`, {
+      const res = await fetch(`/api-v1/team/${encodeURIComponent(payload.id)}`, {
         method:'PATCH', headers: authHeaders(),
         body: JSON.stringify({ name: payload.name, email: payload.email, role: payload.role, active: payload.active })
       });
       if(!res.ok) throw 0;
     } else {
-      const res = await fetch(`${API_PREFIX}/team`, {
+      const res = await fetch(`/api-v1/team`, {
         method:'POST', headers: authHeaders(),
         body: JSON.stringify({ orgId: org.id, name: payload.name, email: payload.email, role: payload.role })
       });
@@ -361,7 +360,7 @@ async function saveMember(payload){
 }
 async function deleteMember(id){
   try{
-    const res = await fetch(`${API_PREFIX}/team/${encodeURIComponent(id)}`, { method:'DELETE', headers: authHeaders() });
+    const res = await fetch(`/api-v1/team/${encodeURIComponent(id)}`, { method:'DELETE', headers: authHeaders() });
     if(!res.ok) throw 0;
   }catch(e){ alert('No se pudo eliminar.'); }
   await loadTeam();
@@ -411,7 +410,7 @@ $('btnSavePlan').addEventListener('click', async ()=>{
   if (plan === 'Team') body.teamMembers = Number($('mTeamSize').value);
 
   try{
-    const res = await fetch(`${API_PREFIX}/org`, {
+    const res = await fetch(`/api-v1/org`, {
       method:'PATCH', headers: authHeaders(), body: JSON.stringify(body)
     });
     if(!res.ok) throw 0;


### PR DESCRIPTION
## Summary
- remove dynamic API host variables in settings and team pages
- reference backend endpoints directly under `/api-v1/*`

## Testing
- `pytest` *(fails: ImportError: email-validator is not installed)*
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c06e6618988325a967d28860886470