### PR TITLE
Ensure data deviceId takes precedence over local storage

### DIFF
--- a/frontend/public/js/apiClient.js
+++ b/frontend/public/js/apiClient.js
@@ -1,10 +1,12 @@
 (function(global){
   async function post(endpoint, data = {}) {
-    const deviceId = localStorage.getItem('deviceId');
+    const localId = localStorage.getItem('deviceId');
+    const payload = { ...data };
+    if (!payload.deviceId && localId) payload.deviceId = localId;
     const res = await fetch(`/api-v1/${endpoint}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ...data, deviceId })
+      body: JSON.stringify(payload)
     });
 
     let body = null;


### PR DESCRIPTION
## Summary
- Retrieve `deviceId` from supplied data before falling back to `localStorage`
- Avoid overwriting explicit `deviceId` with `null` from storage when building request payload

## Testing
- `npm test` (fails: Missing script "test")
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c67e42a7ac8325ab41d9ed091feef6