### PR TITLE
Expose detailed validation errors in FastAPI response

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,7 +22,11 @@ async def app_exception_handler(request, exc: AppException):
 async def validation_exception_handler(request, exc: RequestValidationError):
     return JSONResponse(
         status_code=422,
-        content={"status": 422, "message": "Validation Error"},
+        content={
+            "status": 422,
+            "message": "Validation Error",
+            "errors": exc.errors(),
+        },
     )
 
 

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -43,7 +43,10 @@ def test_contact_validation_error():
     }
     response = client.post(f"{API_PREFIX}/contact", json=payload)
     assert response.status_code == 422
-    assert response.json() == {"status": 422, "message": "Validation Error"}
+    data = response.json()
+    assert data["status"] == 422
+    assert data["message"] == "Validation Error"
+    assert data["errors"][0]["loc"] == ["body", "email"]
 
 
 def test_contact_missing_device_id():
@@ -54,4 +57,7 @@ def test_contact_missing_device_id():
     }
     response = client.post(f"{API_PREFIX}/contact", json=payload)
     assert response.status_code == 422
-    assert response.json() == {"status": 422, "message": "Validation Error"}
+    data = response.json()
+    assert data["status"] == 422
+    assert data["message"] == "Validation Error"
+    assert data["errors"][0]["loc"] == ["body", "deviceId"]

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -51,7 +51,10 @@ def test_validation_error_handler():
 
     response = client.post("/validation-test", json={"wrong": "value"})
     assert response.status_code == 422
-    assert response.json() == {"status": 422, "message": "Validation Error"}
+    data = response.json()
+    assert data["status"] == 422
+    assert data["message"] == "Validation Error"
+    assert data["errors"][0]["loc"] == ["body", "name"]
 
 
 def test_generic_exception_handler():


### PR DESCRIPTION
## Summary
- include `exc.errors()` in `validation_exception_handler` responses
- update tests to assert presence of validation error details

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c67e43cd9c8325b9285a54bf0d6806