### PR TITLE
Create database tables on startup

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1,6 +1,8 @@
 # backend/api/main.py
 from fastapi import FastAPI
 
+from backend.core.database import Base, engine
+
 # Import your routers
 from backend.api.routers import (
     health,
@@ -15,6 +17,13 @@ from backend.api.routers import (
 
 app = FastAPI(title="Tradex Backend")
 
+
+@app.on_event("startup")
+def on_startup() -> None:
+    """Ensure database tables exist."""
+    Base.metadata.create_all(bind=engine)
+
+
 # Mount routers (adjust prefixes/tags if your router files define them differently)
 app.include_router(health.router)   # e.g., GET /health
 app.include_router(tasks.router)    # e.g., /tasks
@@ -25,6 +34,8 @@ app.include_router(organization.router)
 app.include_router(team.router)
 app.include_router(settings.router)
 
+
 @app.get("/")
-def root():
+def root() -> dict[str, str]:
     return {"status": "ok"}
+


### PR DESCRIPTION
## Summary
- Ensure database tables are created when the API starts to avoid missing-table errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c697e941f883258d971b7ecb324fa4