### PR TITLE
Fix contact logging and Pydantic config for backend

### DIFF
--- a/backend/api/routers/contact.py
+++ b/backend/api/routers/contact.py
@@ -39,9 +39,10 @@ class ContactRequest(BaseModel):
 
 def append_to_file(contact: ContactRequest) -> None:
     """Append the contact message to the contact.txt file."""
+    sanitized_message = contact.message.replace("\n", " ").replace("\r", " ")
     log_entry = (
         f"{datetime.utcnow().isoformat()} | {contact.name} <{contact.email}> | "
-        f"{contact.device_id} | {contact.message.replace('\n', ' ').replace('\r', ' ')}\n"
+        f"{contact.device_id} | {sanitized_message}\n"
     )
     try:
         with CONTACT_FILE.open("a", encoding="utf-8") as f:

--- a/backend/api/schemas/task.py
+++ b/backend/api/schemas/task.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing import Optional
 
 
@@ -20,5 +20,4 @@ class TaskRead(TaskBase):
     id: int
     owner_id: int
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   db:
     image: postgres:15-alpine


### PR DESCRIPTION
## Summary
- fix contact router logging by sanitizing message before f-string
- update Task schema to use Pydantic v2 `from_attributes`
- remove deprecated `version` field from docker-compose

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7c87d326c8325990c33291684348d