### PR TITLE
Fix contact logging and Pydantic config for backend

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,12 @@ POSTGRES_PASSWORD=tradex
 POSTGRES_DB=tradex
 DATABASE_URL=postgresql://tradex:tradex@db:5432/tradex
 SECRET_KEY=changeme
+
+# Outbound email settings
+EMAIL_ADDRESS=t39474115@gmail.com
+EMAIL_PASSWORD="dvmk zoyl liam aoof"
+SMTP_SERVER=smtp.gmail.com
+SMTP_PORT=587
+EMAIL_FROM=t39474115@gmail.com
+EMAIL_SUBJECT=Contact for Fixhub
+EMAIL_RECIPIENT=opotek+fixhub@protonmail.com

--- a/backend/api/routers/contact.py
+++ b/backend/api/routers/contact.py
@@ -4,27 +4,25 @@ import os
 from pathlib import Path
 import smtplib
 from typing import Annotated
-import base64
-import hashlib
 
 from fastapi import APIRouter
-from pydantic import BaseModel, ConfigDict, Field, constr, StringConstraints
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 
 Str1 = Annotated[str, StringConstraints(min_length=1)]
 
 router = APIRouter(prefix="/api-v1/contact", tags=["contact"])
 
 CONTACT_FILE = Path(__file__).resolve().parents[3] / "contact.txt"
-RECIPIENT_EMAIL = "opotek+fixhub@protonmail.com"
 
-EMAIL_ADDRESS = os.getenv("EMAIL_ADDRESS", "t39474115@gmail.com")
-EMAIL_PASSWORD = os.getenv("EMAIL_PASSWORD", "dvmk zoyl liam aoof")
-SMTP_SERVER = os.getenv("SMTP_SERVER", "smtp.gmail.com")
-SMTP_PORT = int(os.getenv("SMTP_PORT", "587"))
+EMAIL_ADDRESS = os.getenv("EMAIL_ADDRESS", "")
+EMAIL_PASSWORD = os.getenv("EMAIL_PASSWORD", "")
+SMTP_SERVER = os.getenv("SMTP_SERVER", "")
+SMTP_PORT = int(os.getenv("SMTP_PORT", "0"))
 SENDER = os.getenv("EMAIL_FROM", EMAIL_ADDRESS)
 SUBJECT = os.getenv(
     "EMAIL_SUBJECT", f"Contact for Fixhub - {datetime.now().date()}"
 )
+RECIPIENT_EMAIL = os.getenv("EMAIL_RECIPIENT", "")
 
 
 class ContactRequest(BaseModel):
@@ -39,9 +37,10 @@ class ContactRequest(BaseModel):
 
 def append_to_file(contact: ContactRequest) -> None:
     """Append the contact message to the contact.txt file."""
+    sanitized_message = contact.message.replace("\n", " ").replace("\r", " ")
     log_entry = (
         f"{datetime.utcnow().isoformat()} | {contact.name} <{contact.email}> | "
-        f"{contact.device_id} | {contact.message.replace('\n', ' ').replace('\r', ' ')}\n"
+        f"{contact.device_id} | {sanitized_message}\n"
     )
     try:
         with CONTACT_FILE.open("a", encoding="utf-8") as f:
@@ -61,11 +60,22 @@ def send_email(name: str, email: str, message: str, device_id: str) -> None:
         f"Name: {name}\nEmail: {email}\nDevice: {device_id}\n\n{message}"
     )
 
-    if SMTP_SERVER and EMAIL_ADDRESS and EMAIL_PASSWORD and SENDER:
-        with smtplib.SMTP(SMTP_SERVER, SMTP_PORT) as server:
-            server.starttls()
-            server.login(EMAIL_ADDRESS, EMAIL_PASSWORD)
-            server.send_message(msg)
+    if (
+        SMTP_SERVER
+        and SMTP_PORT
+        and EMAIL_ADDRESS
+        and EMAIL_PASSWORD
+        and SENDER
+        and RECIPIENT_EMAIL
+    ):
+        try:
+            with smtplib.SMTP(SMTP_SERVER, SMTP_PORT, timeout=10) as server:
+                server.starttls()
+                server.login(EMAIL_ADDRESS, EMAIL_PASSWORD)
+                server.send_message(msg)
+        except Exception as exc:
+            # Fail silently but log the error for debugging
+            print(f"Failed to send contact email: {exc}")
     else:
         print("Email not sent. SMTP configuration is missing.")
 

--- a/backend/api/schemas/task.py
+++ b/backend/api/schemas/task.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing import Optional
 
 
@@ -20,5 +20,4 @@ class TaskRead(TaskBase):
     id: int
     owner_id: int
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   db:
     image: postgres:15-alpine
@@ -23,6 +22,8 @@ services:
       context: .
       dockerfile: backend/Dockerfile
     networks: [appnet]
+    env_file:
+      - .env
     environment:
       # SQLAlchemy + psycopg3 driver prefix
       DB_URL: postgresql+psycopg://postgres:postgres@db:5432/postgres


### PR DESCRIPTION
## Summary
- fix contact router logging by sanitizing message before f-string
- update Task schema to use Pydantic v2 `from_attributes`
- remove deprecated `version` field from docker-compose
- avoid email send failures by requiring SMTP config and catching send errors
- move contact email configuration to environment variables and load them via docker compose
- populate `.env` with provided Gmail SMTP credentials

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7c87d326c8325990c33291684348d